### PR TITLE
Split AfterUpload step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ all: planscore/website/build
 
 live-lambda: planscore-lambda.zip
 	env AWS=amazonaws.com WEBSITE_BASE=https://planscore.org/ \
-		parallel -j4 ./deploy.py planscore-lambda.zip \
-		:::  PlanScore-UploadFields PlanScore-AfterUpload PlanScore-RunDistrict PlanScore-ScoreDistrictPlan
+		parallel -j9 ./deploy.py planscore-lambda.zip \
+		:::  PlanScore-UploadFields PlanScore-Callback PlanScore-AfterUpload PlanScore-RunDistrict PlanScore-ScoreDistrictPlan
 
 live-website: planscore/website/build
 	# Two-part sync with deletion after to maintain consistency for web visitors

--- a/deploy.py
+++ b/deploy.py
@@ -11,6 +11,7 @@ if 'AWS_LAMBDA_DLQ_ARN' in os.environ:
 
 functions = {
     'PlanScore-UploadFields': dict(Handler='lambda.upload_fields', Timeout=3, **common),
+    'PlanScore-Callback': dict(Handler='lambda.callback', Timeout=3, **common),
     'PlanScore-AfterUpload': dict(Handler='lambda.after_upload', Timeout=30, **common),
     'PlanScore-RunDistrict': dict(Handler='lambda.run_district', Timeout=300, **common),
     'PlanScore-ScoreDistrictPlan': dict(Handler='lambda.score_plan', Timeout=30, **common),

--- a/deploy.py
+++ b/deploy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import sys, argparse, boto3, os, copy
+import sys, argparse, boto3, os, copy, time
 import botocore.exceptions
 
 common = dict(
@@ -19,6 +19,7 @@ functions = {
 def publish_function(lam, name, path, env, role=None):
     ''' Create or update the named function to Lambda.
     '''
+    start_time = time.time()
     function_kwargs = copy.deepcopy(functions[name])
     function_kwargs['Environment']['Variables'].update(env)
     
@@ -41,6 +42,8 @@ def publish_function(lam, name, path, env, role=None):
         lam.update_function_code(FunctionName=name, ZipFile=code_bytes)
         print('    * update function configuration', name, file=sys.stderr)
         lam.update_function_configuration(FunctionName=name, **function_kwargs)
+    
+    print('      done in {:.1f} seconds'.format(time.time() - start_time), file=sys.stderr)
 
 parser = argparse.ArgumentParser(description='Update Lambda function.')
 parser.add_argument('path', help='Function code path')

--- a/lambda.py
+++ b/lambda.py
@@ -1,4 +1,5 @@
 from planscore.after_upload import lambda_handler as after_upload
 from planscore.upload_fields import lambda_handler as upload_fields
+from planscore.callback import lambda_handler as callback
 from planscore.districts import lambda_handler as run_district
 from planscore.score import lambda_handler as score_plan

--- a/planscore/after_upload.py
+++ b/planscore/after_upload.py
@@ -3,6 +3,8 @@ import itsdangerous
 from osgeo import ogr
 from . import util, data, score, website, prepare_state, districts, constants
 
+FUNCTION_NAME = 'PlanScore-AfterUpload'
+
 ogr.UseExceptions()
 
 states_path = os.path.join(os.path.dirname(__file__), 'geodata', 'cb_2013_us_state_20m.geojson')

--- a/planscore/callback.py
+++ b/planscore/callback.py
@@ -1,4 +1,4 @@
-import boto3, itsdangerous, urllib.parse
+import boto3, itsdangerous, urllib.parse, json
 from . import after_upload, constants, util, website, data, score
 
 def create_upload(s3, bucket, key, id):
@@ -34,10 +34,13 @@ def lambda_handler(event, context):
 
     upload = create_upload(s3, query['bucket'], query['key'], id)
     redirect_url = get_redirect_url(website_base, id)
+    
+    event = dict(bucket=query['bucket'])
+    event.update(upload.to_dict())
 
     lam = boto3.client('lambda', endpoint_url=constants.LAMBDA_ENDPOINT_URL)
     lam.invoke(FunctionName=after_upload.FUNCTION_NAME, InvocationType='Event',
-        Payload=upload.to_json().encode('utf8'))
+        Payload=json.dumps(event).encode('utf8'))
     
     return {
         'statusCode': '302',

--- a/planscore/callback.py
+++ b/planscore/callback.py
@@ -20,7 +20,6 @@ def lambda_handler(event, context):
     '''
     '''
     s3 = boto3.client('s3', endpoint_url=constants.S3_ENDPOINT_URL)
-    lam = boto3.client('lambda', endpoint_url=constants.LAMBDA_ENDPOINT_URL)
     query = util.event_query_args(event)
     website_base = constants.WEBSITE_BASE
 
@@ -36,6 +35,7 @@ def lambda_handler(event, context):
     upload = create_upload(s3, query['bucket'], query['key'], id)
     redirect_url = get_redirect_url(website_base, id)
 
+    lam = boto3.client('lambda', endpoint_url=constants.LAMBDA_ENDPOINT_URL)
     lam.invoke(FunctionName=after_upload.FUNCTION_NAME, InvocationType='Event',
         Payload=upload.to_json().encode('utf8'))
     

--- a/planscore/callback.py
+++ b/planscore/callback.py
@@ -1,0 +1,42 @@
+import boto3, itsdangerous, urllib.parse
+from . import constants, util, website
+
+def get_uploaded_info(s3, bucket, key, id):
+    '''
+    '''
+    pass
+
+def get_redirect_url(website_base, id):
+    '''
+    '''
+    rules = {rule.endpoint: str(rule) for rule in website.app.url_map.iter_rules()}
+    redirect_url = urllib.parse.urljoin(website_base, rules['get_plan'])
+
+    return '{}?{}'.format(redirect_url, id)
+
+def lambda_handler(event, context):
+    '''
+    '''
+    s3 = boto3.client('s3', endpoint_url=constants.S3_ENDPOINT_URL)
+    query = util.event_query_args(event)
+    website_base = constants.WEBSITE_BASE
+
+    try:
+        id = itsdangerous.Signer(constants.SECRET).unsign(query['id']).decode('utf8')
+    except itsdangerous.BadSignature:
+        return {
+            'statusCode': '400',
+            'headers': {'Access-Control-Allow-Origin': '*'},
+            'body': 'Bad ID'
+            }
+    
+    summary = get_uploaded_info(s3, query['bucket'], query['key'], id)
+    redirect_url = get_redirect_url(website_base, id)
+    return {
+        'statusCode': '302',
+        'headers': {'Location': redirect_url},
+        'body': summary
+        }
+
+if __name__ == '__main__':
+    pass

--- a/planscore/tests/test_callback.py
+++ b/planscore/tests/test_callback.py
@@ -40,3 +40,18 @@ class TestCallback (unittest.TestCase):
         self.assertEqual(lambda_dict['InvocationType'], 'Event')
         self.assertIn(b'"id": "id.k0_XwbOLGLUdv241zsPluNc3HYs"', lambda_dict['Payload'])
         self.assertIn(b'"key": "uploads/id/upload/file.geojson"', lambda_dict['Payload'])
+    
+    @unittest.mock.patch('planscore.callback.create_upload')
+    def test_lambda_handler_bad_id(self, create_upload):
+        ''' Lambda event with an incorrectly-signed ID fails as expected
+        '''
+        event = {
+            'queryStringParameters': {'id': 'id.WRONG'}
+            }
+
+        os.environ.update(AWS_ACCESS_KEY_ID='fake-key', AWS_SECRET_ACCESS_KEY='fake-secret')
+        response = callback.lambda_handler(event, None)
+        
+        self.assertFalse(create_upload.mock_calls)
+        self.assertEqual(response['statusCode'], '400')
+        self.assertIn('Bad ID', response['body'])

--- a/planscore/tests/test_callback.py
+++ b/planscore/tests/test_callback.py
@@ -14,6 +14,20 @@ class TestCallback (unittest.TestCase):
         constants.WEBSITE_BASE = self.prev_website
         constants.S3_ENDPOINT_URL = self.prev_s3_url
         constants.LAMBDA_ENDPOINT_URL = self.prev_lam_url
+    
+    @unittest.mock.patch('planscore.score.put_upload_index')
+    def test_create_upload(self, put_upload_index):
+        ''' create_upload() makes the right call to put_upload_index().
+        '''
+        s3, bucket = unittest.mock.Mock(), unittest.mock.Mock()
+        callback.create_upload(s3, bucket, 'example-key', 'example-id')
+        
+        self.assertEqual(len(put_upload_index.mock_calls), 1)
+        self.assertEqual(len(put_upload_index.mock_calls[0][1]), 3)
+        
+        self.assertEqual(put_upload_index.mock_calls[0][1][:2], (s3, bucket))
+        self.assertEqual(put_upload_index.mock_calls[0][1][2].id, 'example-id')
+        self.assertEqual(put_upload_index.mock_calls[0][1][2].key, 'example-key')
 
     @unittest.mock.patch('planscore.callback.create_upload')
     @unittest.mock.patch('boto3.client')

--- a/planscore/tests/test_callback.py
+++ b/planscore/tests/test_callback.py
@@ -20,8 +20,8 @@ class TestCallback (unittest.TestCase):
     def test_lambda_handler(self, boto3_client, create_upload):
         ''' Lambda event triggers the right call to create_upload()
         '''
-        query = {'id': 'id.k0_XwbOLGLUdv241zsPluNc3HYs', 'bucket': 'planscore',
-            'key': data.UPLOAD_PREFIX.format(id='id') + 'file.geojson'}
+        query = {'key': data.UPLOAD_PREFIX.format(id='id') + 'file.geojson',
+            'id': 'id.k0_XwbOLGLUdv241zsPluNc3HYs', 'bucket': 'planscore-bucket'}
 
         os.environ.update(AWS_ACCESS_KEY_ID='fake-key', AWS_SECRET_ACCESS_KEY='fake-secret')
 
@@ -40,6 +40,7 @@ class TestCallback (unittest.TestCase):
         self.assertEqual(lambda_dict['InvocationType'], 'Event')
         self.assertIn(b'"id": "id.k0_XwbOLGLUdv241zsPluNc3HYs"', lambda_dict['Payload'])
         self.assertIn(b'"key": "uploads/id/upload/file.geojson"', lambda_dict['Payload'])
+        self.assertIn(b'"bucket": "planscore-bucket"', lambda_dict['Payload'])
     
     @unittest.mock.patch('planscore.callback.create_upload')
     def test_lambda_handler_bad_id(self, create_upload):

--- a/planscore/tests/test_callback.py
+++ b/planscore/tests/test_callback.py
@@ -1,0 +1,35 @@
+import unittest, unittest.mock, os
+from .. import callback, data, districts, constants
+
+class TestCallback (unittest.TestCase):
+
+    def setUp(self):
+        self.prev_secret, constants.SECRET = constants.SECRET, 'fake-secret'
+        self.prev_website, constants.WEBSITE_BASE = constants.WEBSITE_BASE, 'https://example.com/'
+        self.prev_s3_url, constants.S3_ENDPOINT_URL = constants.S3_ENDPOINT_URL, None
+        self.prev_lam_url, constants.LAMBDA_ENDPOINT_URL = constants.LAMBDA_ENDPOINT_URL, None
+    
+    def tearDown(self):
+        constants.SECRET = self.prev_secret
+        constants.WEBSITE_BASE = self.prev_website
+        constants.S3_ENDPOINT_URL = self.prev_s3_url
+        constants.LAMBDA_ENDPOINT_URL = self.prev_lam_url
+
+    @unittest.mock.patch('planscore.callback.get_uploaded_info')
+    def test_lambda_handler(self, get_uploaded_info):
+        ''' Lambda event triggers the right call to get_uploaded_info()
+        '''
+        query = {'id': 'id.k0_XwbOLGLUdv241zsPluNc3HYs', 'bucket': 'planscore',
+            'key': data.UPLOAD_PREFIX.format(id='id') + 'file.geojson'}
+
+        os.environ.update(AWS_ACCESS_KEY_ID='fake-key', AWS_SECRET_ACCESS_KEY='fake-secret')
+
+        get_uploaded_info.return_value = 'get_uploaded_info.return_value'
+        response = callback.lambda_handler({'queryStringParameters': query}, None)
+        
+        self.assertEqual(response['statusCode'], '302')
+        self.assertIn(get_uploaded_info.return_value, response['body'])
+        self.assertEqual(response['headers']['Location'], 'https://example.com/plan.html?id')
+        
+        self.assertEqual(get_uploaded_info.mock_calls[0][1][1:],
+            (query['bucket'], query['key'], 'id'))

--- a/planscore/website/__init__.py
+++ b/planscore/website/__init__.py
@@ -110,7 +110,7 @@ def get_localstack_lambda(path):
 
     function_name = {
         constants.API_UPLOAD_RELPATH: 'PlanScore-UploadFields',
-        constants.API_UPLOADED_RELPATH: 'PlanScore-AfterUpload',
+        constants.API_UPLOADED_RELPATH: 'PlanScore-Callback',
         }[path]
 
     lam = boto3.client('lambda', endpoint_url=constants.LAMBDA_ENDPOINT_URL,

--- a/setup-localstack.py
+++ b/setup-localstack.py
@@ -16,12 +16,6 @@ ENDPOINT_S3 = 'http://{}:4572'.format(host_address)
 ENDPOINT_LAM = 'http://{}:4574'.format(host_address)
 AWS_CREDS = dict(aws_access_key_id='nobody', aws_secret_access_key='nothing')
 CODE_PATH = arguments.code_path
-FUNCTIONS = [
-    ('PlanScore-UploadFields', 'lambda.upload_fields', 3),
-    ('PlanScore-AfterUpload', 'lambda.after_upload', 30),
-    ('PlanScore-RunDistrict', 'lambda.run_district', 300),
-    ('PlanScore-ScoreDistrictPlan', 'lambda.score_plan', 30),
-    ]
 
 # S3 Bucket setup
 
@@ -79,5 +73,5 @@ env = {
 
 print('    Environment:', ' '.join(['='.join(kv) for kv in env.items()]))
 
-for (function_name, handler, timeout) in FUNCTIONS:
+for function_name in deploy.functions.keys():
     deploy.publish_function(lam, function_name, CODE_PATH, env, 'nobody')


### PR DESCRIPTION
Insert a new step immediately before AfterUpload extracts data, so that a plan uploader does not experience a lengthy delay before being redirected to a score page.