### PR TITLE
Handling of gzip and no-gzip output

### DIFF
--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -252,10 +252,13 @@ def load_tile_precincts(storage, tile_zxy):
             return []
         raise
 
+    # decode the body into a plain JSON string, gzippped or not
     if object.get('ContentEncoding') == 'gzip':
-        object['Body'] = io.BytesIO(gzip.decompress(object['Body'].read()))
-    
-    geojson = json.load(object['Body'])
+        object['Body'] = gzip.decompress(object['Body'].read()).decode()
+    else:
+        object['Body'] = object['Body'].read().decode()
+
+    geojson = json.loads(object['Body'])
     return geojson['features']
 
 def iterate_precincts(storage, precincts, tiles):

--- a/planscore/score.py
+++ b/planscore/score.py
@@ -74,10 +74,13 @@ def score_district(s3, bucket, district_geom, tiles_prefix):
                 continue
             raise
 
+        # decode the body into a JSON byte string, gzippped or not
         if object.get('ContentEncoding') == 'gzip':
-            object['Body'] = io.BytesIO(gzip.decompress(object['Body'].read()))
+            object['Body'] = gzip.decompress(object['Body'].read())
+        else:
+            object['Body'] = object['Body'].read()
         
-        with util.temporary_buffer_file('tile.geojson', object['Body']) as path:
+        with util.temporary_string_file('tile.geojson', object['Body']) as path:
             ds = ogr.Open(path)
             defn = ds.GetLayer(0).GetLayerDefn()
             fields = [defn.GetFieldDefn(i).name for i in range(defn.GetFieldCount())]

--- a/planscore/score.py
+++ b/planscore/score.py
@@ -80,7 +80,7 @@ def score_district(s3, bucket, district_geom, tiles_prefix):
         else:
             object['Body'] = object['Body'].read()
         
-        with util.temporary_string_file('tile.geojson', object['Body']) as path:
+        with util.temporary_bytes_file('tile.geojson', object['Body']) as path:
             ds = ogr.Open(path)
             defn = ds.GetLayer(0).GetLayerDefn()
             fields = [defn.GetFieldDefn(i).name for i in range(defn.GetFieldCount())]

--- a/planscore/util.py
+++ b/planscore/util.py
@@ -12,9 +12,9 @@ def temporary_buffer_file(filename, buffer):
         shutil.rmtree(dirname)
 
 @contextlib.contextmanager
-def temporary_string_file(filename, contents):
+def temporary_bytes_file(filename, contents):
     try:
-        dirname = tempfile.mkdtemp(prefix='temporary_string_file-')
+        dirname = tempfile.mkdtemp(prefix='temporary_bytes_file-')
         filepath = os.path.join(dirname, filename)
         with open(filepath, 'wb') as file:
             file.write(contents)  # expects bytes not string, e.g. "hello".encode()

--- a/planscore/util.py
+++ b/planscore/util.py
@@ -11,6 +11,17 @@ def temporary_buffer_file(filename, buffer):
     finally:
         shutil.rmtree(dirname)
 
+@contextlib.contextmanager
+def temporary_string_file(filename, contents):
+    try:
+        dirname = tempfile.mkdtemp(prefix='temporary_string_file-')
+        filepath = os.path.join(dirname, filename)
+        with open(filepath, 'wb') as file:
+            file.write(contents)  # expects bytes not string, e.g. "hello".encode()
+        yield filepath
+    finally:
+        shutil.rmtree(dirname)
+
 def event_url(event):
     '''
     '''


### PR DESCRIPTION
See issue #49 

Unit tests were failing because decoding of gzip-encoded content was returning a BytesIO object which `json.load()` did not like. Updated 3 instances of this behavior.
