### PR TITLE
Handle output from many EG simulations

### DIFF
--- a/data/sample-NC-simulations/index.json
+++ b/data/sample-NC-simulations/index.json
@@ -1,0 +1,101 @@
+{
+  "districts": [
+    {
+      "totals": {
+        "Democratic Votes": 1028053.906695856, "Democratic Votes SD": 10000,
+        "Republican Votes": 1140266.0413978184, "Republican Votes SD": 10000,
+        "Voters": 733321.7355470409
+      }
+    },
+    {
+      "totals": {
+        "Democratic Votes": 722739.2336584385, "Democratic Votes SD": 10000,
+        "Republican Votes": 1250376.1917409902, "Republican Votes SD": 10000,
+        "Voters": 733916.6092098424
+      }
+    },
+    {
+      "totals": {
+        "Democratic Votes": 861316.383834584, "Democratic Votes SD": 10000,
+        "Republican Votes": 1009192.6409346957, "Republican Votes SD": 10000,
+        "Voters": 733214.7769512797
+      }
+    },
+    {
+      "totals": {
+        "Democratic Votes": 861136.3638968371, "Democratic Votes SD": 10000,
+        "Republican Votes": 1029233.6012586453, "Republican Votes SD": 10000,
+        "Voters": 733641.0644435043
+      }
+    },
+    {
+      "totals": {
+        "Democratic Votes": 1168163.7891999995, "Democratic Votes SD": 10000,
+        "Republican Votes": 910221.1861484455, "Republican Votes SD": 10000,
+        "Voters": 733355.3824566011
+      }
+    },
+    {
+      "totals": {
+        "Democratic Votes": 858331.6521125122, "Democratic Votes SD": 10000,
+        "Republican Votes": 1187564.0539012533, "Republican Votes SD": 10000,
+        "Voters": 733427.9539901235
+      }
+    },
+    {
+      "totals": {
+        "Democratic Votes": 902593.3844505954, "Democratic Votes SD": 10000,
+        "Republican Votes": 1099054.9469762954, "Republican Votes SD": 10000,
+        "Voters": 733427.3294434798
+      }
+    },
+    {
+      "totals": {
+        "Democratic Votes": 1408003.5743913983, "Democratic Votes SD": 10000,
+        "Republican Votes": 860046.6161929097, "Republican Votes SD": 10000,
+        "Voters": 733274.1858270672
+      }
+    },
+    {
+      "totals": {
+        "Democratic Votes": 1241765.0654939467, "Democratic Votes SD": 10000,
+        "Republican Votes": 1036160.1827196102, "Republican Votes SD": 10000,
+        "Voters": 733688.8778878144
+      }
+    },
+    {
+      "totals": {
+        "Democratic Votes": 1058949.6076082457, "Democratic Votes SD": 10000,
+        "Republican Votes": 991790.9031673878, "Republican Votes SD": 10000,
+        "Voters": 733377.4439753302
+      }
+    },
+    {
+      "totals": {
+        "Democratic Votes": 917158.9099286381, "Democratic Votes SD": 10000,
+        "Republican Votes": 799204.386551063, "Republican Votes SD": 10000,
+        "Voters": 733571.9961659344
+      }
+    },
+    {
+      "totals": {
+        "Democratic Votes": 1057149.9221458216, "Democratic Votes SD": 10000,
+        "Republican Votes": 842269.1055301814, "Republican Votes SD": 10000,
+        "Voters": 733187.702836184
+      }
+    },
+    {
+      "totals": {
+        "Democratic Votes": 841420.1306598457, "Democratic Votes SD": 10000,
+        "Republican Votes": 1149160.4424367815, "Republican Votes SD": 10000,
+        "Voters": 733250.2429033419
+      }
+    }
+  ],
+  "id": "20170603T032332.301188632Z",
+  "key": "uploads/20170603T032332.301188632Z/upload/NC-plan-1-992.geojson",
+  "summary": {
+    "Efficiency Gap": -0.017041439381461233,
+    "Efficiency Gap SD": 0.0017
+  }
+}

--- a/planscore/tests/test_score.py
+++ b/planscore/tests/test_score.py
@@ -107,6 +107,19 @@ class TestScore (unittest.TestCase):
         output = score.calculate_gaps(score.calculate_gap(input))
         self.assertEqual(output.summary['Efficiency Gap'], -.125)
         self.assertAlmostEqual(output.summary['Efficiency Gap SD'], .1767767)
+        
+        for field in ('REP000', 'DEM000', 'REP001', 'DEM001'):
+            for district in output.districts:
+                self.assertNotIn(field, district['totals'])
+
+        self.assertEqual(output.districts[0]['totals']['Republican Votes'], 3/2)
+        self.assertEqual(output.districts[0]['totals']['Democratic Votes'], 13/2)
+        self.assertEqual(output.districts[1]['totals']['Republican Votes'], 8/2)
+        self.assertEqual(output.districts[1]['totals']['Democratic Votes'], 8/2)
+        self.assertEqual(output.districts[2]['totals']['Republican Votes'], 10/2)
+        self.assertEqual(output.districts[2]['totals']['Democratic Votes'], 6/2)
+        self.assertEqual(output.districts[3]['totals']['Republican Votes'], 11/2)
+        self.assertEqual(output.districts[3]['totals']['Democratic Votes'], 5/2)
 
     def test_score_district(self):
         ''' District scores are correctly read from input GeoJSON

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -77,6 +77,11 @@ function which_score_summary_name(plan)
 
 function which_score_column_names(plan)
 {
+    if(typeof plan.summary['Efficiency Gap SD'] === 'number')
+    {
+        return ['Voters', 'Democratic Votes', 'Republican Votes'];
+    }
+
     if(typeof plan.summary['US House Efficiency Gap'] === 'number')
     {
         return [
@@ -98,6 +103,15 @@ function which_district_color(district, plan)
     var totals = district.totals,
         color_red = '#D45557',
         color_blue = '#4D90D1';
+
+    if(typeof plan.summary['Efficiency Gap SD'] === 'number')
+    {
+        if(totals['Democratic Votes'] > totals['Republican Votes']) {
+            return color_blue;
+        } else {
+            return color_red;
+        }
+    }
 
     if(typeof plan.summary['US House Efficiency Gap'] === 'number')
     {

--- a/tests.js
+++ b/tests.js
@@ -3,7 +3,8 @@ plan = require('planscore/website/static/plan.js');
 
 var NC_index = require('data/sample-NC-1-992/index.json'),
     NC_incomplete_index = require('data/sample-NC-1-992-incomplete/index.json'),
-    NC_simple_index = require('data/sample-NC-1-992-simple/index.json');
+    NC_simple_index = require('data/sample-NC-1-992-simple/index.json'),
+    NC_multisim_index = require('data/sample-NC-simulations/index.json');
 
 // Old-style red vs. blue plan
 
@@ -52,6 +53,23 @@ assert.equal(plan.which_district_color(NC_index.districts[0], NC_index),
     '#D45557', 'Should return the red district color');
 
 assert.equal(plan.which_district_color(NC_index.districts[7], NC_index),
+    '#4D90D1', 'Should return the blue district color');
+
+// New-style North Carolina plan with confidence intervals from simulations
+
+assert.equal(plan.what_score_description_html(NC_multisim_index),
+    '<i>No description provided</i>', 'Should find the right description');
+
+assert.equal(plan.which_score_summary_name(NC_multisim_index),
+    'Efficiency Gap', 'Should pick out the right summary name');
+
+assert.deepEqual(plan.which_score_column_names(NC_multisim_index),
+    ['Voters', 'Democratic Votes', 'Republican Votes'], 'Should pick out the right column names');
+
+assert.equal(plan.which_district_color(NC_multisim_index.districts[0], NC_multisim_index),
+    '#D45557', 'Should return the red district color');
+
+assert.equal(plan.which_district_color(NC_multisim_index.districts[7], NC_multisim_index),
     '#4D90D1', 'Should return the blue district color');
 
 // Assorted functions


### PR DESCRIPTION
Display the right numbers generated by simulation process. Ignore the confidence intervals for now, but use their presence to determine what to show.