### PR TITLE
Pass district geometries via S3

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -12,7 +12,7 @@ if 'AWS_LAMBDA_DLQ_ARN' in os.environ:
 functions = {
     'PlanScore-UploadFields': dict(Handler='lambda.upload_fields', Timeout=3, **common),
     'PlanScore-Callback': dict(Handler='lambda.callback', Timeout=3, **common),
-    'PlanScore-AfterUpload': dict(Handler='lambda.after_upload', Timeout=30, **common),
+    'PlanScore-AfterUpload': dict(Handler='lambda.after_upload', Timeout=90, **common),
     'PlanScore-RunDistrict': dict(Handler='lambda.run_district', Timeout=300, **common),
     'PlanScore-ScoreDistrictPlan': dict(Handler='lambda.score_plan', Timeout=30, **common),
     }

--- a/planscore/data.py
+++ b/planscore/data.py
@@ -4,7 +4,7 @@ UPLOAD_PREFIX = 'uploads/{id}/upload/'
 UPLOAD_INDEX_KEY = 'uploads/{id}/index.json'
 UPLOAD_GEOMETRY_KEY = 'uploads/{id}/geometry.json'
 UPLOAD_DISTRICTS_KEY = 'uploads/{id}/districts/{index}.json'
-UPLOAD_GEOMETRIES_KEY = 'uploads/{id}/districts/{index}.wkt'
+UPLOAD_GEOMETRIES_KEY = 'uploads/{id}/geometries/{index}.wkt'
 
 class Storage:
     ''' Wrapper for S3-related details.

--- a/planscore/data.py
+++ b/planscore/data.py
@@ -4,6 +4,7 @@ UPLOAD_PREFIX = 'uploads/{id}/upload/'
 UPLOAD_INDEX_KEY = 'uploads/{id}/index.json'
 UPLOAD_GEOMETRY_KEY = 'uploads/{id}/geometry.json'
 UPLOAD_DISTRICTS_KEY = 'uploads/{id}/districts/{index}.json'
+UPLOAD_GEOMETRIES_KEY = 'uploads/{id}/districts/{index}.wkt'
 
 class Storage:
     ''' Wrapper for S3-related details.

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -29,6 +29,13 @@ class Partial:
         
         self._geometry = geometry
         self._tile_geoms = {}
+        
+        if hasattr(geometry, 'ExportToWkt'):
+            # Old-style OGR geometry object
+            self._event_geometry = geometry.ExportToWkt()
+        else:
+            # Newer-style geometry S3 key
+            self._event_geometry = geometry
     
     def to_dict(self):
         return dict(index=self.index, totals=self.totals,
@@ -37,7 +44,7 @@ class Partial:
     
     def to_event(self):
         return dict(index=self.index, totals=self.totals, tiles=self.tiles,
-            geometry=self.geometry.ExportToWkt(), upload=self.upload.to_dict(),
+            geometry=self._event_geometry, upload=self.upload.to_dict(),
             precincts=Partial.scrunch(self.precincts))
     
     @property
@@ -66,13 +73,20 @@ class Partial:
         return self.geometry.Contains(tile_geometry(tile_zxy))
     
     @staticmethod
-    def from_event(event, s3):
+    def from_event(event, storage):
         totals = event.get('totals')
         precincts = event.get('precincts')
         tiles = event.get('tiles')
-        geometry = ogr.CreateGeometryFromWkt(event['geometry'])
         index = event['index']
         upload = data.Upload.from_dict(event['upload'])
+        
+        try:
+            # Old-style WKT literal value
+            geometry = ogr.CreateGeometryFromWkt(event['geometry'])
+        except:
+            # Newer-style geometry S3 key
+            object = storage.s3.get_object(Bucket=storage.bucket, Key=event['geometry'])
+            geometry = ogr.CreateGeometryFromWkt(object['Body'].read().decode('utf8'))
         
         if totals is None or precincts is None or tiles is None:
             totals, precincts, tiles = collections.defaultdict(int), [], get_geometry_tile_zxys(geometry)
@@ -113,8 +127,8 @@ def lambda_handler(event, context):
     '''
     '''
     s3 = boto3.client('s3', endpoint_url=constants.S3_ENDPOINT_URL)
-    partial = Partial.from_event(event, s3)
     storage = data.Storage.from_event(event, s3)
+    partial = Partial.from_event(event, storage)
 
     start_time, times = time.time(), []
     

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -66,7 +66,7 @@ class Partial:
         return self.geometry.Contains(tile_geometry(tile_zxy))
     
     @staticmethod
-    def from_event(event):
+    def from_event(event, s3):
         totals = event.get('totals')
         precincts = event.get('precincts')
         tiles = event.get('tiles')
@@ -113,7 +113,7 @@ def lambda_handler(event, context):
     '''
     '''
     s3 = boto3.client('s3', endpoint_url=constants.S3_ENDPOINT_URL)
-    partial = Partial.from_event(event)
+    partial = Partial.from_event(event, s3)
     storage = data.Storage.from_event(event, s3)
 
     start_time, times = time.time(), []

--- a/planscore/tests/test_after_upload.py
+++ b/planscore/tests/test_after_upload.py
@@ -80,7 +80,7 @@ class TestAfterUpload (unittest.TestCase):
         upload = data.Upload('ID', 'uploads/ID/upload/file.geojson')
         null_plan_path = os.path.join(os.path.dirname(__file__), 'data', 'null-plan.geojson')
         keys = after_upload.put_district_geometries(s3, 'bucket-name', upload, null_plan_path)
-        self.assertEqual(keys, ['uploads/ID/districts/0.wkt', 'uploads/ID/districts/1.wkt'])
+        self.assertEqual(keys, ['uploads/ID/geometries/0.wkt', 'uploads/ID/geometries/1.wkt'])
     
     @unittest.mock.patch('sys.stdout')
     @unittest.mock.patch('boto3.client')
@@ -89,7 +89,7 @@ class TestAfterUpload (unittest.TestCase):
         '''
         upload = data.Upload('ID', 'uploads/ID/upload/file.geojson')
         after_upload.fan_out_district_lambdas('bucket-name', 'data/XX', upload,
-            ['uploads/ID/districts/0.wkt', 'uploads/ID/districts/1.wkt'])
+            ['uploads/ID/geometries/0.wkt', 'uploads/ID/geometries/1.wkt'])
         
         for (index, call) in enumerate(boto3_client.return_value.mock_calls):
             kwargs = call[2]
@@ -99,7 +99,7 @@ class TestAfterUpload (unittest.TestCase):
             self.assertIn(b'bucket-name', kwargs['Payload'])
             self.assertIn(b'data/XX', kwargs['Payload'])
             self.assertIn(b'"id": "ID"', kwargs['Payload'])
-            self.assertIn(f'"geometry": "uploads/ID/districts/{index}.wkt"'.encode('utf8'), kwargs['Payload'])
+            self.assertIn(f'"geometry": "uploads/ID/geometries/{index}.wkt"'.encode('utf8'), kwargs['Payload'])
             self.assertIn(b'"districts": [null, null]', kwargs['Payload'],
                 'Should have the right number of districts even though they are blanks')
     

--- a/planscore/tests/test_after_upload.py
+++ b/planscore/tests/test_after_upload.py
@@ -79,9 +79,8 @@ class TestAfterUpload (unittest.TestCase):
         s3 = unittest.mock.Mock()
         upload = data.Upload('ID', 'uploads/ID/upload/file.geojson')
         null_plan_path = os.path.join(os.path.dirname(__file__), 'data', 'null-plan.geojson')
-        urls = after_upload.put_district_geometries(s3, 'bucket-name', upload, null_plan_path)
-        
-        self.assertEqual(len(urls), 2)
+        keys = after_upload.put_district_geometries(s3, 'bucket-name', upload, null_plan_path)
+        self.assertEqual(keys, ['uploads/ID/districts/0.wkt', 'uploads/ID/districts/1.wkt'])
     
     @unittest.mock.patch('sys.stdout')
     @unittest.mock.patch('boto3.client')
@@ -90,7 +89,7 @@ class TestAfterUpload (unittest.TestCase):
         '''
         upload = data.Upload('ID', 'uploads/ID/upload/file.geojson')
         after_upload.fan_out_district_lambdas('bucket-name', 'data/XX', upload,
-            ['http://example.com/0.wkt', 'http://example.com/1.wkt'])
+            ['uploads/ID/districts/0.wkt', 'uploads/ID/districts/1.wkt'])
         
         for (index, call) in enumerate(boto3_client.return_value.mock_calls):
             kwargs = call[2]
@@ -100,7 +99,7 @@ class TestAfterUpload (unittest.TestCase):
             self.assertIn(b'bucket-name', kwargs['Payload'])
             self.assertIn(b'data/XX', kwargs['Payload'])
             self.assertIn(b'"id": "ID"', kwargs['Payload'])
-            self.assertIn(f'"geometry": "http://example.com/{index}.wkt"'.encode('utf8'), kwargs['Payload'])
+            self.assertIn(f'"geometry": "uploads/ID/districts/{index}.wkt"'.encode('utf8'), kwargs['Payload'])
             self.assertIn(b'"districts": [null, null]', kwargs['Payload'],
                 'Should have the right number of districts even though they are blanks')
     

--- a/planscore/tests/test_after_upload.py
+++ b/planscore/tests/test_after_upload.py
@@ -73,14 +73,24 @@ class TestAfterUpload (unittest.TestCase):
         nc_plan_path = os.path.join(os.path.dirname(__file__), 'data', 'NC-plan-1-992.geojson')
         self.assertEqual(after_upload.guess_state(nc_plan_path), 'NC')
     
+    def test_put_district_geometries(self):
+        '''
+        '''
+        s3 = unittest.mock.Mock()
+        upload = data.Upload('ID', 'uploads/ID/upload/file.geojson')
+        null_plan_path = os.path.join(os.path.dirname(__file__), 'data', 'null-plan.geojson')
+        urls = after_upload.put_district_geometries(s3, 'bucket-name', upload, null_plan_path)
+        
+        self.assertEqual(len(urls), 2)
+    
     @unittest.mock.patch('sys.stdout')
     @unittest.mock.patch('boto3.client')
     def test_fan_out_district_lambdas(self, boto3_client, stdout):
         ''' Test that district Lambda fan-out is invoked correctly.
         '''
         upload = data.Upload('ID', 'uploads/ID/upload/file.geojson')
-        null_plan_path = os.path.join(os.path.dirname(__file__), 'data', 'null-plan.geojson')
-        after_upload.fan_out_district_lambdas('bucket-name', 'data/XX', upload, null_plan_path)
+        after_upload.fan_out_district_lambdas('bucket-name', 'data/XX', upload,
+            ['http://example.com/0.wkt', 'http://example.com/1.wkt'])
         
         for (index, call) in enumerate(boto3_client.return_value.mock_calls):
             kwargs = call[2]
@@ -90,15 +100,17 @@ class TestAfterUpload (unittest.TestCase):
             self.assertIn(b'bucket-name', kwargs['Payload'])
             self.assertIn(b'data/XX', kwargs['Payload'])
             self.assertIn(b'"id": "ID"', kwargs['Payload'])
+            self.assertIn(f'"geometry": "http://example.com/{index}.wkt"'.encode('utf8'), kwargs['Payload'])
             self.assertIn(b'"districts": [null, null]', kwargs['Payload'],
                 'Should have the right number of districts even though they are blanks')
     
     @unittest.mock.patch('planscore.util.temporary_buffer_file')
     @unittest.mock.patch('planscore.score.put_upload_index')
     @unittest.mock.patch('planscore.after_upload.put_geojson_file')
+    @unittest.mock.patch('planscore.after_upload.put_district_geometries')
     @unittest.mock.patch('planscore.after_upload.fan_out_district_lambdas')
     @unittest.mock.patch('planscore.after_upload.guess_state')
-    def test_commence_upload_scoring_good_file(self, guess_state, fan_out_district_lambdas, put_geojson_file, put_upload_index, temporary_buffer_file):
+    def test_commence_upload_scoring_good_file(self, guess_state, fan_out_district_lambdas, put_district_geometries, put_geojson_file, put_upload_index, temporary_buffer_file):
         ''' A valid district plan file is scored and the results posted to S3
         '''
         id = 'ID'
@@ -125,18 +137,22 @@ class TestAfterUpload (unittest.TestCase):
         put_upload_index.assert_called_once_with(s3, bucket, upload)
         put_geojson_file.assert_called_once_with(s3, bucket, upload, nullplan_path)
         
+        self.assertEqual(len(put_district_geometries.mock_calls), 1)
+        self.assertEqual(put_district_geometries.mock_calls[0][1][3], nullplan_path)
+
         self.assertEqual(len(fan_out_district_lambdas.mock_calls), 1)
         self.assertEqual(fan_out_district_lambdas.mock_calls[0][1][:2], (bucket, 'data/XX/002'))
         self.assertEqual(fan_out_district_lambdas.mock_calls[0][1][2].key, upload.key)
-        self.assertEqual(fan_out_district_lambdas.mock_calls[0][1][3], nullplan_path)
+        self.assertEqual(fan_out_district_lambdas.mock_calls[0][1][3], put_district_geometries.return_value)
     
     @unittest.mock.patch('planscore.util.temporary_buffer_file')
     @unittest.mock.patch('planscore.score.put_upload_index')
     @unittest.mock.patch('planscore.after_upload.put_geojson_file')
     @unittest.mock.patch('planscore.after_upload.unzip_shapefile')
+    @unittest.mock.patch('planscore.after_upload.put_district_geometries')
     @unittest.mock.patch('planscore.after_upload.fan_out_district_lambdas')
     @unittest.mock.patch('planscore.after_upload.guess_state')
-    def test_commence_upload_scoring_zipped_file(self, guess_state, fan_out_district_lambdas, unzip_shapefile, put_geojson_file, put_upload_index, temporary_buffer_file):
+    def test_commence_upload_scoring_zipped_file(self, guess_state, fan_out_district_lambdas, put_district_geometries, unzip_shapefile, put_geojson_file, put_upload_index, temporary_buffer_file):
         ''' A valid district plan zipfile is scored and the results posted to S3
         '''
         id = 'ID'
@@ -166,10 +182,13 @@ class TestAfterUpload (unittest.TestCase):
         self.assertEqual(put_geojson_file.mock_calls[0][1][:3], (s3, bucket, upload))
         self.assertIs(put_geojson_file.mock_calls[0][1][3], unzip_shapefile.return_value)
         
+        self.assertEqual(len(put_district_geometries.mock_calls), 1)
+        self.assertEqual(put_district_geometries.mock_calls[0][1][3], unzip_shapefile.return_value)
+        
         self.assertEqual(len(fan_out_district_lambdas.mock_calls), 1)
         self.assertEqual(fan_out_district_lambdas.mock_calls[0][1][:2], (bucket, 'data/XX/002'))
         self.assertEqual(fan_out_district_lambdas.mock_calls[0][1][2].key, upload.key)
-        self.assertIs(fan_out_district_lambdas.mock_calls[0][1][3], unzip_shapefile.return_value)
+        self.assertIs(fan_out_district_lambdas.mock_calls[0][1][3], put_district_geometries.return_value)
     
     def test_commence_upload_scoring_bad_file(self):
         ''' An invalid district file fails in an expected way

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -23,9 +23,11 @@ class TestDistricts (unittest.TestCase):
     def test_Partial_key(self):
         ''' Partial.from_event() creates the right properties with geometry key.
         '''
-        s3 = unittest.mock.Mock()
+        storage = unittest.mock.Mock()
+        storage.s3.get_object.return_value = {'Body': io.BytesIO(b'POINT (0.00001 0.00001)')}
+
         partial = districts.Partial.from_event(dict(index=-1, geometry='uploads/0/districts/0.wkt',
-            upload={'id': 'ID', 'key': 'uploads/ID/upload/file.geojson'}), s3)
+            upload={'id': 'ID', 'key': 'uploads/ID/upload/file.geojson'}), storage)
         self.assertEqual(str(partial.geometry), 'POINT (0.00001 0.00001)')
         self.assertEqual(partial.index, -1)
         self.assertEqual(partial.totals, {})
@@ -36,9 +38,9 @@ class TestDistricts (unittest.TestCase):
     def test_Partial_wkt(self):
         ''' Partial.from_event() creates the right properties with geometry WKT.
         '''
-        s3 = unittest.mock.Mock()
+        storage = unittest.mock.Mock()
         partial = districts.Partial.from_event(dict(index=-1, geometry='POINT(0.00001 0.00001)',
-            upload={'id': 'ID', 'key': 'uploads/ID/upload/file.geojson'}), s3)
+            upload={'id': 'ID', 'key': 'uploads/ID/upload/file.geojson'}), storage)
         self.assertEqual(str(partial.geometry), 'POINT (0.00001 0.00001)')
         self.assertEqual(partial.index, -1)
         self.assertEqual(partial.totals, {})
@@ -94,13 +96,13 @@ class TestDistricts (unittest.TestCase):
     def test_Partial_to_event(self):
         ''' Partial.to_event() and .from_event() work together.
         '''
-        s3 = unittest.mock.Mock()
+        storage = unittest.mock.Mock()
         partial1 = districts.Partial(0, {},
             [{"type": "Feature", "properties": {"GEOID": "3", "NAME": "Precinct 3", "Voters": 4, "Red Votes": 3, "Blue Votes": 0, "PlanScore:Fraction": 0.563558429345361}, "geometry": {"type": "Polygon", "coordinates": [[[-0.0003853, 0.0], [-0.0003819, 2.5e-06], [-0.0003824, 1.16e-05], [-0.0003895, 1.16e-05], [-0.000391, 1.47e-05], [-0.0003922, 2.1e-05], [-0.0003832, 3.27e-05], [-0.0003844, 3.81e-05], [-0.0003751, 5.2e-05], [-0.0003683, 5.48e-05], [-0.0003685, 5.99e-05], [-0.0003642, 6.45e-05], [-0.0003597, 6.45e-05], [-0.0003531, 6.45e-05], [-0.0003432, 6.91e-05], [-0.0003379, 6.96e-05], [-0.0003321, 7.06e-05], [-0.0003273, 7.72e-05], [-0.0003268, 8.46e-05], [-0.0003185, 8.97e-05], [-0.0003109, 9.04e-05], [-0.0003064, 9.5e-05], [-0.0002973, 9.45e-05], [-0.0002978, 0.0001047], [-0.0002887, 0.0001103], [-0.0002826, 0.0001067], [-0.0002746, 0.0001042], [-0.0002756, 0.0001164], [-0.0002852, 0.0001179], [-0.0002852, 0.0001245], [-0.0002776, 0.0001291], [-0.0002776, 0.0001438], [-0.0002756, 0.0001464], [-0.00027, 0.0001474], [-0.0002644, 0.0001606], [-0.0002619, 0.0001657], [-0.0002518, 0.0001632], [-0.0002463, 0.0001738], [-0.0002397, 0.0001728], [-0.0002286, 0.0001815], [-0.0002225, 0.0001815], [-0.0002205, 0.0001922], [-0.0002154, 0.0001947], [-0.0002114, 0.0002049], [-0.0001973, 0.0002166], [-0.0001952, 0.0002237], [-0.0001811, 0.0002181], [-0.0001821, 0.000213], [-0.0001882, 0.0002038], [-0.0001856, 0.0001988], [-0.0001856, 0.0001942], [-0.0001882, 0.000184], [-0.0001826, 0.000184], [-0.000176, 0.0001749], [-0.0001715, 0.0001754], [-0.0001634, 0.0001866], [-0.0001594, 0.0001876], [-0.0001538, 0.0001916], [-0.0001478, 0.0001855], [-0.0001382, 0.0001922], [-0.0001255, 0.0001906], [-0.000125, 0.000183], [-0.000118, 0.0001825], [-0.0001175, 0.0001898], [-3.16e-05, 0.0], [-0.0003853, 0.0]]]}}],
             ["whatever"], ogr.CreateGeometryFromWkt('POLYGON ((-0.0002360 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,-0.0000268 -0.0004693,-0.0000187 -0.0000214,-0.0002360 0.0004532))'),
             data.Upload('ID', 'key.json'))
         
-        partial2 = districts.Partial.from_event(partial1.to_event(), s3)
+        partial2 = districts.Partial.from_event(partial1.to_event(), storage)
         
         self.assertEqual(partial2.index, partial1.index)
         self.assertEqual(partial2.precincts[0], partial1.precincts[0])

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -1,4 +1,4 @@
-import unittest, os, json, io, gzip, itertools
+import unittest, unittest.mock, os, json, io, gzip, itertools
 from osgeo import ogr
 import botocore.exceptions
 from .. import districts, data, score
@@ -20,11 +20,25 @@ def mock_s3_get_object(Bucket, Key):
 
 class TestDistricts (unittest.TestCase):
 
-    def test_Partial(self):
-        ''' Partial.from_event() creates the right properties.
+    def test_Partial_key(self):
+        ''' Partial.from_event() creates the right properties with geometry key.
         '''
+        s3 = unittest.mock.Mock()
+        partial = districts.Partial.from_event(dict(index=-1, geometry='uploads/0/districts/0.wkt',
+            upload={'id': 'ID', 'key': 'uploads/ID/upload/file.geojson'}), s3)
+        self.assertEqual(str(partial.geometry), 'POINT (0.00001 0.00001)')
+        self.assertEqual(partial.index, -1)
+        self.assertEqual(partial.totals, {})
+        self.assertEqual(partial.precincts, [])
+        self.assertEqual(partial.tiles, ['12/2048/2047'])
+        self.assertEqual(partial.upload.id, 'ID')
+    
+    def test_Partial_wkt(self):
+        ''' Partial.from_event() creates the right properties with geometry WKT.
+        '''
+        s3 = unittest.mock.Mock()
         partial = districts.Partial.from_event(dict(index=-1, geometry='POINT(0.00001 0.00001)',
-            upload={'id': 'ID', 'key': 'uploads/ID/upload/file.geojson'}))
+            upload={'id': 'ID', 'key': 'uploads/ID/upload/file.geojson'}), s3)
         self.assertEqual(str(partial.geometry), 'POINT (0.00001 0.00001)')
         self.assertEqual(partial.index, -1)
         self.assertEqual(partial.totals, {})
@@ -80,12 +94,13 @@ class TestDistricts (unittest.TestCase):
     def test_Partial_to_event(self):
         ''' Partial.to_event() and .from_event() work together.
         '''
+        s3 = unittest.mock.Mock()
         partial1 = districts.Partial(0, {},
             [{"type": "Feature", "properties": {"GEOID": "3", "NAME": "Precinct 3", "Voters": 4, "Red Votes": 3, "Blue Votes": 0, "PlanScore:Fraction": 0.563558429345361}, "geometry": {"type": "Polygon", "coordinates": [[[-0.0003853, 0.0], [-0.0003819, 2.5e-06], [-0.0003824, 1.16e-05], [-0.0003895, 1.16e-05], [-0.000391, 1.47e-05], [-0.0003922, 2.1e-05], [-0.0003832, 3.27e-05], [-0.0003844, 3.81e-05], [-0.0003751, 5.2e-05], [-0.0003683, 5.48e-05], [-0.0003685, 5.99e-05], [-0.0003642, 6.45e-05], [-0.0003597, 6.45e-05], [-0.0003531, 6.45e-05], [-0.0003432, 6.91e-05], [-0.0003379, 6.96e-05], [-0.0003321, 7.06e-05], [-0.0003273, 7.72e-05], [-0.0003268, 8.46e-05], [-0.0003185, 8.97e-05], [-0.0003109, 9.04e-05], [-0.0003064, 9.5e-05], [-0.0002973, 9.45e-05], [-0.0002978, 0.0001047], [-0.0002887, 0.0001103], [-0.0002826, 0.0001067], [-0.0002746, 0.0001042], [-0.0002756, 0.0001164], [-0.0002852, 0.0001179], [-0.0002852, 0.0001245], [-0.0002776, 0.0001291], [-0.0002776, 0.0001438], [-0.0002756, 0.0001464], [-0.00027, 0.0001474], [-0.0002644, 0.0001606], [-0.0002619, 0.0001657], [-0.0002518, 0.0001632], [-0.0002463, 0.0001738], [-0.0002397, 0.0001728], [-0.0002286, 0.0001815], [-0.0002225, 0.0001815], [-0.0002205, 0.0001922], [-0.0002154, 0.0001947], [-0.0002114, 0.0002049], [-0.0001973, 0.0002166], [-0.0001952, 0.0002237], [-0.0001811, 0.0002181], [-0.0001821, 0.000213], [-0.0001882, 0.0002038], [-0.0001856, 0.0001988], [-0.0001856, 0.0001942], [-0.0001882, 0.000184], [-0.0001826, 0.000184], [-0.000176, 0.0001749], [-0.0001715, 0.0001754], [-0.0001634, 0.0001866], [-0.0001594, 0.0001876], [-0.0001538, 0.0001916], [-0.0001478, 0.0001855], [-0.0001382, 0.0001922], [-0.0001255, 0.0001906], [-0.000125, 0.000183], [-0.000118, 0.0001825], [-0.0001175, 0.0001898], [-3.16e-05, 0.0], [-0.0003853, 0.0]]]}}],
             ["whatever"], ogr.CreateGeometryFromWkt('POLYGON ((-0.0002360 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,-0.0000268 -0.0004693,-0.0000187 -0.0000214,-0.0002360 0.0004532))'),
             data.Upload('ID', 'key.json'))
         
-        partial2 = districts.Partial.from_event(partial1.to_event())
+        partial2 = districts.Partial.from_event(partial1.to_event(), s3)
         
         self.assertEqual(partial2.index, partial1.index)
         self.assertEqual(partial2.precincts[0], partial1.precincts[0])


### PR DESCRIPTION
We were seeing some AWS Lambda `RequestEntityTooLargeException` errors with complex or detailed plans. This PR modifies the event structure to include an S3 key in place of a geometry WKT literal.