### PR TITLE
#55 updated README to specify Python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ Lambda. To make local development possible, use Docker and the local AWS
 development stack [LocalStack](https://github.com/localstack/localstack).
 
 1.  Clone the PlanScore git repository and prepare a
-    [Python virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/#virtualenv).
+    [Python virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/#virtualenv) running **Python 3.6**.
+    ```
+    virtualenv -p /usr/bin/python3.6 planscore_folder    
+    ```
+    To enter the virtualenv would then be:
+    ```
+    source planscore_folder/bin/activate
+    ```
 
 2.  Install GDAL 2.1.3, a binary dependency required by PlanScore.
     See _GDAL_ section below for more details on operating systems.


### PR DESCRIPTION
Relevant to #55    The code now uses f-strings which are specific to Python 3.6

This improves the documentation to make this clear.
