### PR TITLE
Added deployment to AWS S3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,17 @@
+dependencies:
+  override:
+    # Stop Circle from trying to set up all the NPM dependencies
+    - echo No Worries
+
+test:
+  override:
+    # Don't run any tests
+    - echo Hello World
+
+deployment:
+  production:
+    branch: [gh-pages]
+    commands:
+      # Two-part sync with deletion after to maintain consistency for web visitors
+      - aws s3 sync --acl public-read --cache-control 'public, max-age=300' WEBSITE_OUTPUT/ s3://planscore.org-static-site/
+      - aws s3 sync --acl public-read --cache-control 'public, max-age=300' --delete WEBSITE_OUTPUT/ s3://planscore.org-static-site/


### PR DESCRIPTION
Ask Circle to push to S3. For now I’ve created a bucket visible here: http://planscore.org-static-site.s3-website-us-east-1.amazonaws.com/

- For later, update our Cloudfront distribution to merge this bucket and the one controlled by the master branch.
- This change may also make Github pages redundant, so consider renaming this branch from `gh-pages` to `static-site`.