### PR TITLE
Added sensitivity testing data to summary

### DIFF
--- a/planscore/score.py
+++ b/planscore/score.py
@@ -134,16 +134,25 @@ def score_district(s3, bucket, district_geom, tiles_prefix):
     
     return totals, tile_list, output.getvalue()
 
-def calculate_EG(red_districts, blue_districts):
+def calculate_EG(red_districts, blue_districts, vote_swing=0):
     ''' Convert two lists of district vote counts into an EG score.
+    
+        Vote swing is positive toward blue and negative toward red.
     '''
     election_votes, wasted_red, wasted_blue, red_wins, blue_wins = 0, 0, 0, 0, 0
     
+    # Swing the vote, if necessary
+    if vote_swing != 0:
+        districts = [(R, B, R + B) for (R, B) in zip(red_districts, blue_districts)]
+        red_districts = [((R/T - vote_swing) * T) for (R, B, T) in districts]
+        blue_districts = [((B/T + vote_swing) * T) for (R, B, T) in districts]
+    
+    # Calculate Efficiency Gap using swung vote
     for (red_votes, blue_votes) in zip(red_districts, blue_districts):
         district_votes = red_votes + blue_votes
         election_votes += district_votes
         win_threshold = district_votes / 2
-
+        
         if red_votes > blue_votes:
             red_wins += 1
             wasted_red += red_votes - win_threshold # surplus

--- a/planscore/tests/test_score.py
+++ b/planscore/tests/test_score.py
@@ -26,14 +26,32 @@ class TestScore (unittest.TestCase):
     def test_calculate_EG_fair(self):
         ''' Efficiency gap can be correctly calculated for a fair election
         '''
-        gap = score.calculate_EG((2, 3, 5, 6), (6, 5, 3, 2))
-        self.assertEqual(gap, 0)
+        gap1 = score.calculate_EG((2, 3, 5, 6), (6, 5, 3, 2))
+        self.assertAlmostEqual(gap1, 0)
+
+        gap2 = score.calculate_EG((2, 3, 5, 6), (6, 5, 3, 2), -.1)
+        self.assertAlmostEqual(gap2, .2, msg='Should see slight +blue EG with a +red vote swing')
+
+        gap3 = score.calculate_EG((2, 3, 5, 6), (6, 5, 3, 2), .1)
+        self.assertAlmostEqual(gap3, -.2, msg='Should see slight +red EG with a +blue vote swing')
+
+        gap4 = score.calculate_EG((2, 3, 5, 6), (6, 5, 3, 2), 0)
+        self.assertAlmostEqual(gap4, gap1, msg='Should see identical EG with unchanged vote swing')
 
     def test_calculate_EG_unfair(self):
         ''' Efficiency gap can be correctly calculated for an unfair election
         '''
-        gap = score.calculate_EG((1, 5, 5, 5), (7, 3, 3, 3))
-        self.assertEqual(gap, -.25)
+        gap1 = score.calculate_EG((1, 5, 5, 5), (7, 3, 3, 3))
+        self.assertAlmostEqual(gap1, -.25)
+
+        gap2 = score.calculate_EG((1, 5, 5, 5), (7, 3, 3, 3), -.1)
+        self.assertAlmostEqual(gap2, -.05, msg='Should see lesser +red EG with a +red vote swing')
+
+        gap3 = score.calculate_EG((1, 5, 5, 5), (7, 3, 3, 3), .1)
+        self.assertAlmostEqual(gap3, -.45, msg='Should see larger +red EG with a +blue vote swing')
+
+        gap4 = score.calculate_EG((1, 5, 5, 5), (7, 3, 3, 3), 0)
+        self.assertAlmostEqual(gap4, gap1, msg='Should see identical EG with unchanged vote swing')
 
     @unittest.mock.patch('planscore.score.calculate_EG')
     def test_calculate_gap(self, calculate_EG):

--- a/planscore/tests/test_score.py
+++ b/planscore/tests/test_score.py
@@ -161,8 +161,16 @@ class TestScore (unittest.TestCase):
         output = score.calculate_gaps(score.calculate_gap(input))
         self.assertEqual(output.summary['Efficiency Gap'], calculate_EG.return_value)
         self.assertEqual(output.summary['Efficiency Gap SD'], 0)
-        self.assertEqual(calculate_EG.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2]))
-        self.assertEqual(calculate_EG.mock_calls[1][1], ([1, 5, 5, 5], [7, 3, 3, 3]))
+        self.assertIn('Efficiency Gap +1 Dem', output.summary)
+        self.assertIn('Efficiency Gap +1 Dem SD', output.summary)
+        self.assertIn('Efficiency Gap +1 Rep', output.summary)
+        self.assertIn('Efficiency Gap +1 Rep SD', output.summary)
+        self.assertEqual(calculate_EG.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2], 0))
+        self.assertEqual(calculate_EG.mock_calls[1][1], ([2, 3, 5, 6], [6, 5, 3, 2], .01))
+        self.assertEqual(calculate_EG.mock_calls[2][1], ([2, 3, 5, 6], [6, 5, 3, 2], -.01))
+        self.assertEqual(calculate_EG.mock_calls[11][1], ([1, 5, 5, 5], [7, 3, 3, 3], 0))
+        self.assertEqual(calculate_EG.mock_calls[12][1], ([1, 5, 5, 5], [7, 3, 3, 3], .01))
+        self.assertEqual(calculate_EG.mock_calls[13][1], ([1, 5, 5, 5], [7, 3, 3, 3], -.01))
         
         for field in ('REP000', 'DEM000', 'REP001', 'DEM001'):
             for district in output.districts:

--- a/planscore/tests/test_score.py
+++ b/planscore/tests/test_score.py
@@ -66,8 +66,15 @@ class TestScore (unittest.TestCase):
                 ])
         
         output = score.calculate_gaps(score.calculate_gap(input))
+
         self.assertEqual(output.summary['Efficiency Gap'], calculate_EG.return_value)
-        calculate_EG.assert_called_once_with([2, 3, 5, 6], [6, 5, 3, 2])
+        self.assertEqual(calculate_EG.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2]))
+
+        self.assertEqual(output.summary['Efficiency Gap +1 Blue'], calculate_EG.return_value)
+        self.assertEqual(calculate_EG.mock_calls[1][1], ([2, 3, 5, 6], [6, 5, 3, 2], .01))
+
+        self.assertEqual(output.summary['Efficiency Gap +1 Red'], calculate_EG.return_value)
+        self.assertEqual(calculate_EG.mock_calls[2][1], ([2, 3, 5, 6], [6, 5, 3, 2], -.01))
 
     @unittest.mock.patch('planscore.score.calculate_EG')
     def test_calculate_gap_ushouse(self, calculate_EG):
@@ -82,8 +89,15 @@ class TestScore (unittest.TestCase):
                 ])
         
         output = score.calculate_gaps(score.calculate_gap(input))
+
         self.assertEqual(output.summary['US House Efficiency Gap'], calculate_EG.return_value)
-        calculate_EG.assert_called_once_with([2, 3, 5, 6], [6, 5, 3, 2])
+        self.assertEqual(calculate_EG.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2]))
+
+        self.assertEqual(output.summary['US House Efficiency Gap +1 Dem'], calculate_EG.return_value)
+        self.assertEqual(calculate_EG.mock_calls[1][1], ([2, 3, 5, 6], [6, 5, 3, 2], .01))
+
+        self.assertEqual(output.summary['US House Efficiency Gap +1 Rep'], calculate_EG.return_value)
+        self.assertEqual(calculate_EG.mock_calls[2][1], ([2, 3, 5, 6], [6, 5, 3, 2], -.01))
 
     @unittest.mock.patch('planscore.score.calculate_EG')
     def test_calculate_gap_upperhouse(self, calculate_EG):
@@ -98,8 +112,15 @@ class TestScore (unittest.TestCase):
                 ])
         
         output = score.calculate_gaps(score.calculate_gap(input))
+
         self.assertEqual(output.summary['SLDU Efficiency Gap'], calculate_EG.return_value)
-        calculate_EG.assert_called_once_with([2, 3, 5, 6], [6, 5, 3, 2])
+        self.assertEqual(calculate_EG.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2]))
+
+        self.assertEqual(output.summary['SLDU Efficiency Gap +1 Dem'], calculate_EG.return_value)
+        self.assertEqual(calculate_EG.mock_calls[1][1], ([2, 3, 5, 6], [6, 5, 3, 2], .01))
+
+        self.assertEqual(output.summary['SLDU Efficiency Gap +1 Rep'], calculate_EG.return_value)
+        self.assertEqual(calculate_EG.mock_calls[2][1], ([2, 3, 5, 6], [6, 5, 3, 2], -.01))
 
     @unittest.mock.patch('planscore.score.calculate_EG')
     def test_calculate_gap_lowerhouse(self, calculate_EG):
@@ -114,8 +135,15 @@ class TestScore (unittest.TestCase):
                 ])
         
         output = score.calculate_gaps(score.calculate_gap(input))
+
         self.assertEqual(output.summary['SLDL Efficiency Gap'], calculate_EG.return_value)
-        calculate_EG.assert_called_once_with([2, 3, 5, 6], [6, 5, 3, 2])
+        self.assertEqual(calculate_EG.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2]))
+
+        self.assertEqual(output.summary['SLDL Efficiency Gap +1 Dem'], calculate_EG.return_value)
+        self.assertEqual(calculate_EG.mock_calls[1][1], ([2, 3, 5, 6], [6, 5, 3, 2], .01))
+
+        self.assertEqual(output.summary['SLDL Efficiency Gap +1 Rep'], calculate_EG.return_value)
+        self.assertEqual(calculate_EG.mock_calls[2][1], ([2, 3, 5, 6], [6, 5, 3, 2], -.01))
 
     @unittest.mock.patch('planscore.score.calculate_EG')
     def test_calculate_gap_sims(self, calculate_EG):


### PR DESCRIPTION
Calculate EG at 1-point vote swing intervals from -5 to +5, output everything in the result summary dict with standard deviations for multiple-simulation models:

    "summary": {
      "Efficiency Gap": 0.0820,
      "Efficiency Gap SD": 0.044,

      "Efficiency Gap +1 Dem": 0.0620,
      "Efficiency Gap +1 Rep": 0.1020,
      "Efficiency Gap +2 Dem": 0.0420,
      "Efficiency Gap +2 Rep": 0.1220,
      "Efficiency Gap +3 Dem": 0.022,
      "Efficiency Gap +3 Rep": 0.1420,
      "Efficiency Gap +4 Dem": 0.002004,
      "Efficiency Gap +4 Rep": 0.1620,
      "Efficiency Gap +5 Dem": -0.01799,
      "Efficiency Gap +5 Rep": 0.1820,

      "Efficiency Gap +1 Dem SD": 0.044,
      "Efficiency Gap +1 Rep SD": 0.04401,
      "Efficiency Gap +2 Dem SD": 0.0440,
      "Efficiency Gap +2 Rep SD": 0.044,
      "Efficiency Gap +3 Dem SD": 0.04401,
      "Efficiency Gap +3 Rep SD": 0.04401,
      "Efficiency Gap +4 Dem SD": 0.04401,
      "Efficiency Gap +4 Rep SD": 0.0440,
      "Efficiency Gap +5 Dem SD": 0.0440,
      "Efficiency Gap +5 Rep SD": 0.0440
    }
