### PR TITLE
Add Reock and Polsby-Popper compactness scores

### DIFF
--- a/planscore/after_upload.py
+++ b/planscore/after_upload.py
@@ -89,7 +89,7 @@ def fan_out_district_lambdas(bucket, prefix, upload, geometry_keys):
         lam = boto3.client('lambda', endpoint_url=constants.LAMBDA_ENDPOINT_URL)
         
         for (index, geometry_key) in enumerate(geometry_keys):
-            partial = districts.Partial(index, None, None, None, geometry_key, upload, None)
+            partial = districts.Partial(index, None, None, None, None, geometry_key, upload, None)
             payload = dict(partial.to_event(), bucket=bucket, prefix=prefix)
 
             lam.invoke(FunctionName=districts.FUNCTION_NAME, InvocationType='Event',

--- a/planscore/compactness/__init__.py
+++ b/planscore/compactness/__init__.py
@@ -1,2 +1,32 @@
+import math, itertools
+from osgeo import ogr, osr
+from . import smallestenclosingcircle
+
+# Spherical mercator should work at typical district sizes
+EPSG4326 = osr.SpatialReference(); EPSG4326.ImportFromEPSG(4326)
+EPSG3857 = osr.SpatialReference(); EPSG3857.ImportFromEPSG(3857)
+projection = osr.CoordinateTransformation(EPSG4326, EPSG3857)
+
 def get_scores(geometry):
     return {}
+
+def get_reock_score(geometry):
+    ''' Return area ratio of geometry to minimum bounding circle
+        
+        More on Reock score:
+        https://github.com/cicero-data/compactness-stats/wiki#reock
+    '''
+    projected = geometry.Clone()
+    projected.Transform(projection)
+    boundary = projected.GetBoundary()
+    geom_area = projected.GetArea()
+    
+    if boundary.GetGeometryType() in (ogr.wkbMultiLineString, ogr.wkbMultiLineString25D):
+        geoms = [boundary.GetGeometryRef(i) for i in range(boundary.GetGeometryCount())]
+        points = itertools.chain(*[[geom.GetPoint(i)[:2]
+            for i in range(1, geom.GetPointCount())] for geom in geoms])
+    else:
+        points = [boundary.GetPoint(i)[:2] for i in range(1, boundary.GetPointCount())]
+
+    _, _, radius = smallestenclosingcircle.make_circle(points)
+    return geom_area / (math.pi * radius * radius)

--- a/planscore/compactness/__init__.py
+++ b/planscore/compactness/__init__.py
@@ -8,7 +8,16 @@ EPSG3857 = osr.SpatialReference(); EPSG3857.ImportFromEPSG(3857)
 projection = osr.CoordinateTransformation(EPSG4326, EPSG3857)
 
 def get_scores(geometry):
-    return {}
+    ''' Return dictionary of compactness scores for a geographic area.
+    '''
+    scores = dict()
+    
+    try:
+        scores['Reock'] = get_reock_score(geometry)
+    except Exception:
+        scores['Reock'] = None
+    
+    return scores
 
 def get_reock_score(geometry):
     ''' Return area ratio of geometry to minimum bounding circle

--- a/planscore/compactness/__init__.py
+++ b/planscore/compactness/__init__.py
@@ -1,0 +1,2 @@
+def get_scores(geometry):
+    return {}

--- a/planscore/compactness/smallestenclosingcircle.py
+++ b/planscore/compactness/smallestenclosingcircle.py
@@ -1,0 +1,129 @@
+# 
+# Smallest enclosing circle - Library (Python)
+# 
+# Copyright (c) 2017 Project Nayuki
+# https://www.nayuki.io/page/smallest-enclosing-circle
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+# 
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program (see COPYING.txt and COPYING.LESSER.txt).
+# If not, see <http://www.gnu.org/licenses/>.
+# 
+
+import math, random
+
+
+# Data conventions: A point is a pair of floats (x, y). A circle is a triple of floats (center x, center y, radius).
+
+# Returns the smallest circle that encloses all the given points. Runs in expected O(n) time, randomized.
+# Input: A sequence of pairs of floats or ints, e.g. [(0,5), (3.1,-2.7)].
+# Output: A triple of floats representing a circle.
+# Note: If 0 points are given, None is returned. If 1 point is given, a circle of radius 0 is returned.
+# 
+# Initially: No boundary points known
+def make_circle(points):
+	# Convert to float and randomize order
+	shuffled = [(float(x), float(y)) for (x, y) in points]
+	random.shuffle(shuffled)
+	
+	# Progressively add points to circle or recompute circle
+	c = None
+	for (i, p) in enumerate(shuffled):
+		if c is None or not is_in_circle(c, p):
+			c = _make_circle_one_point(shuffled[ : i + 1], p)
+	return c
+
+
+# One boundary point known
+def _make_circle_one_point(points, p):
+	c = (p[0], p[1], 0.0)
+	for (i, q) in enumerate(points):
+		if not is_in_circle(c, q):
+			if c[2] == 0.0:
+				c = make_diameter(p, q)
+			else:
+				c = _make_circle_two_points(points[ : i + 1], p, q)
+	return c
+
+
+# Two boundary points known
+def _make_circle_two_points(points, p, q):
+	circ = make_diameter(p, q)
+	left = None
+	right = None
+	px, py = p
+	qx, qy = q
+	
+	# For each point not in the two-point circle
+	for r in points:
+		if is_in_circle(circ, r):
+			continue
+		
+		# Form a circumcircle and classify it on left or right side
+		cross = _cross_product(px, py, qx, qy, r[0], r[1])
+		c = make_circumcircle(p, q, r)
+		if c is None:
+			continue
+		elif cross > 0.0 and (left is None or _cross_product(px, py, qx, qy, c[0], c[1]) > _cross_product(px, py, qx, qy, left[0], left[1])):
+			left = c
+		elif cross < 0.0 and (right is None or _cross_product(px, py, qx, qy, c[0], c[1]) < _cross_product(px, py, qx, qy, right[0], right[1])):
+			right = c
+	
+	# Select which circle to return
+	if left is None and right is None:
+		return circ
+	elif left is None:
+		return right
+	elif right is None:
+		return left
+	else:
+		return left if (left[2] <= right[2]) else right
+
+
+def make_circumcircle(p0, p1, p2):
+	# Mathematical algorithm from Wikipedia: Circumscribed circle
+	ax, ay = p0
+	bx, by = p1
+	cx, cy = p2
+	ox = (min(ax, bx, cx) + max(ax, bx, cx)) / 2.0
+	oy = (min(ay, by, cy) + max(ay, by, cy)) / 2.0
+	ax -= ox; ay -= oy
+	bx -= ox; by -= oy
+	cx -= ox; cy -= oy
+	d = (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) * 2.0
+	if d == 0.0:
+		return None
+	x = ox + ((ax * ax + ay * ay) * (by - cy) + (bx * bx + by * by) * (cy - ay) + (cx * cx + cy * cy) * (ay - by)) / d
+	y = oy + ((ax * ax + ay * ay) * (cx - bx) + (bx * bx + by * by) * (ax - cx) + (cx * cx + cy * cy) * (bx - ax)) / d
+	ra = math.hypot(x - p0[0], y - p0[1])
+	rb = math.hypot(x - p1[0], y - p1[1])
+	rc = math.hypot(x - p2[0], y - p2[1])
+	return (x, y, max(ra, rb, rc))
+
+
+def make_diameter(p0, p1):
+	cx = (p0[0] + p1[0]) / 2.0
+	cy = (p0[1] + p1[1]) / 2.0
+	r0 = math.hypot(cx - p0[0], cy - p0[1])
+	r1 = math.hypot(cx - p1[0], cy - p1[1])
+	return (cx, cy, max(r0, r1))
+
+
+_MULTIPLICATIVE_EPSILON = 1 + 1e-14
+
+def is_in_circle(c, p):
+	return c is not None and math.hypot(p[0] - c[0], p[1] - c[1]) <= c[2] * _MULTIPLICATIVE_EPSILON
+
+
+# Returns twice the signed area of the triangle defined by (x0, y0), (x1, y1), (x2, y2).
+def _cross_product(x0, y0, x1, y1, x2, y2):
+	return (x1 - x0) * (y2 - y0) - (y1 - y0) * (x2 - x0)

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -171,7 +171,7 @@ def post_score_results(storage, partial):
     ''' Post single-district counts.
     '''
     key = partial.upload.district_key(partial.index)
-    body = json.dumps(dict(totals=partial.totals), indent=2).encode('utf8')
+    body = json.dumps(partial.to_dict(), indent=2).encode('utf8')
     
     print('Uploading', len(body), 'bytes to', key)
     

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -6,7 +6,7 @@ AWS Lambda time limit before recursively calling for remaining tiles.
 import collections, json, io, gzip, statistics, time, base64, posixpath, pickle, functools
 from osgeo import ogr
 import boto3, botocore.exceptions, ModestMaps.OpenStreetMap, ModestMaps.Core
-from . import prepare_state, score, data, constants
+from . import prepare_state, score, data, constants, compactness
 
 ogr.UseExceptions()
 
@@ -126,6 +126,10 @@ def lambda_handler(event, context):
     
     print('Starting with', len(partial.precincts),
         'precincts and', len(partial.tiles), 'tiles remaining')
+    
+    if not partial.compactness:
+        # Before running through tiles, record district compactness measures
+        partial.compactness.update(compactness.get_scores(partial.geometry))
 
     for (index, _) in enumerate(consume_tiles(storage, partial)):
         times.append(time.time() - start_time)

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -18,9 +18,10 @@ _mercator = ModestMaps.OpenStreetMap.Provider().projection
 class Partial:
     ''' Partially-calculated district sums, used by consume_tiles().
     '''
-    def __init__(self, index, totals, precincts, tiles, geometry_key, upload, ogr_geometry):
+    def __init__(self, index, totals, compactness, precincts, tiles, geometry_key, upload, ogr_geometry):
         self.index = index
         self.totals = totals
+        self.compactness = compactness
         self.precincts = precincts
         self.geometry_key = geometry_key
         self.tiles = tiles
@@ -31,13 +32,13 @@ class Partial:
     
     def to_dict(self):
         return dict(index=self.index, totals=self.totals,
-            precincts=len(self.precincts), tiles=self.tiles,
-            upload=self.upload.to_dict())
+            compactness=self.compactness, precincts=len(self.precincts),
+            tiles=self.tiles, upload=self.upload.to_dict())
     
     def to_event(self):
         return dict(index=self.index, totals=self.totals, tiles=self.tiles,
-            geometry_key=self.geometry_key, upload=self.upload.to_dict(),
-            precincts=Partial.scrunch(self.precincts))
+            compactness=self.compactness, geometry_key=self.geometry_key,
+            upload=self.upload.to_dict(), precincts=Partial.scrunch(self.precincts))
     
     @property
     def geometry(self):
@@ -67,6 +68,7 @@ class Partial:
     @staticmethod
     def from_event(event, storage):
         totals = event.get('totals')
+        compactness = event.get('compactness')
         precincts = event.get('precincts')
         tiles = event.get('tiles')
         index = event['index']
@@ -76,10 +78,12 @@ class Partial:
         object = storage.s3.get_object(Bucket=storage.bucket, Key=geometry_key)
         geometry = ogr.CreateGeometryFromWkt(object['Body'].read().decode('utf8'))
         
-        if totals is None or precincts is None or tiles is None:
-            totals, precincts, tiles = collections.defaultdict(int), [], get_geometry_tile_zxys(geometry)
+        if totals is None or compactness is None or precincts is None or tiles is None:
+            totals, compactness = collections.defaultdict(int), {}
+            precincts, tiles = [], get_geometry_tile_zxys(geometry)
         
-        return Partial(index, totals, Partial.unscrunch(precincts), tiles, geometry_key, upload, geometry)
+        return Partial(index, totals, compactness, Partial.unscrunch(precincts),
+            tiles, geometry_key, upload, geometry)
     
     @staticmethod
     def scrunch(thing):
@@ -163,7 +167,7 @@ def post_score_results(storage, partial):
     ''' Post single-district counts.
     '''
     key = partial.upload.district_key(partial.index)
-    body = json.dumps(dict(totals=partial.totals, geometry_key=partial.geometry_key)).encode('utf8')
+    body = json.dumps(dict(totals=partial.totals), indent=2).encode('utf8')
     
     print('Uploading', len(body), 'bytes to', key)
     

--- a/planscore/score.py
+++ b/planscore/score.py
@@ -220,7 +220,11 @@ def combine_district_scores(storage, input_upload):
         if object.get('ContentEncoding') == 'gzip':
             object['Body'] = io.BytesIO(gzip.decompress(object['Body'].read()))
         
-        new_districts.append(json.load(object['Body']))
+        new_district = {key: value for (key, value)
+            in json.load(object['Body']).items()
+            if key in ('totals', 'compactness')}
+        
+        new_districts.append(new_district)
 
     interim_upload = calculate_gap(input_upload.clone(districts=new_districts))
     output_upload = calculate_gaps(interim_upload)

--- a/planscore/tests/data/uploads/sample-plan/districts/0.json
+++ b/planscore/tests/data/uploads/sample-plan/districts/0.json
@@ -1,4 +1,6 @@
 {
     "totals": {"Voters": 600.6907822573452, "Blue Votes": 140.91376204910148, "Red Votes": 339.63886375677475},
+    "compactness": {"Reock": 0.58986716},
+    "upload": null,
     "geometry_key": "uploads/sample-plan/geometries/0.wkt"
 }

--- a/planscore/tests/data/uploads/sample-plan/districts/1.json
+++ b/planscore/tests/data/uploads/sample-plan/districts/1.json
@@ -1,4 +1,6 @@
 {
     "totals": {"Voters": 899.3092177419549, "Blue Votes": 459.0862379504786, "Red Votes": 260.3611362430853},
+    "compactness": {"Reock": 0.53540118},
+    "upload": null,
     "geometry_key": "uploads/sample-plan/geometries/1.wkt"
 }

--- a/planscore/tests/test_after_upload.py
+++ b/planscore/tests/test_after_upload.py
@@ -134,7 +134,9 @@ class TestAfterUpload (unittest.TestCase):
         after_upload.fan_out_district_lambdas('bucket-name', 'data/XX', upload,
             ['uploads/ID/geometries/0.wkt', 'uploads/ID/geometries/1.wkt'])
         
-        for (index, call) in enumerate(boto3_client.return_value.mock_calls):
+        self.assertEqual(len(boto3_client.return_value.invoke.mock_calls), 2)
+        
+        for (index, call) in enumerate(boto3_client.return_value.invoke.mock_calls):
             kwargs = call[2]
             self.assertEqual(kwargs['FunctionName'], districts.FUNCTION_NAME)
             self.assertEqual(kwargs['InvocationType'], 'Event')

--- a/planscore/tests/test_compactness.py
+++ b/planscore/tests/test_compactness.py
@@ -1,0 +1,20 @@
+import unittest, math
+from osgeo import ogr
+from .. import compactness
+
+class TestCompactness (unittest.TestCase):
+    
+    def test_reock_score(self):
+        ''' Reock score looks about right
+        '''
+        # A square around Lake Merritt
+        geom1 = ogr.CreateGeometryFromJson('{"type": "Polygon", "coordinates": [[[-122.2631266, 37.7987797], [-122.2631266, 37.8103489], [-122.2484841, 37.8103489], [-122.2484841, 37.7987797], [-122.2631266, 37.7987797]]]}')
+        self.assertAlmostEqual(compactness.get_reock_score(geom1), 2/math.pi, places=5)
+
+        # A thin line through Lake Merritt
+        geom2 = ogr.CreateGeometryFromJson('{"type": "Polygon", "coordinates": [[[-122.2631266, 37.804111], [-122.2631266, 37.804112], [-122.2484841, 37.804112], [-122.2484841, 37.804111], [-122.2631266, 37.804111]]]}')
+        self.assertAlmostEqual(compactness.get_reock_score(geom2), 0., places=3)
+
+        # A square around Lake Merritt with a peephole in it
+        geom3 = ogr.CreateGeometryFromJson('{"type": "Polygon", "coordinates": [[[-122.2631266, 37.7987797], [-122.2631266, 37.8103489], [-122.2484841, 37.8103489], [-122.2484841, 37.7987797], [-122.2631266, 37.7987797]], [[-122.257189, 37.804124], [-122.257189, 37.804132], [-122.257178, 37.804132], [-122.257178, 37.804124], [-122.257189, 37.804124]]]}')
+        self.assertAlmostEqual(compactness.get_reock_score(geom3), 2/math.pi, places=5)

--- a/planscore/tests/test_compactness.py
+++ b/planscore/tests/test_compactness.py
@@ -1,8 +1,33 @@
-import unittest, math
+import unittest, unittest.mock, math
 from osgeo import ogr
 from .. import compactness
 
+def raises_exception():
+    raise Exception('Well actually')
+
 class TestCompactness (unittest.TestCase):
+
+    @unittest.mock.patch('planscore.compactness.get_reock_score')
+    def test_get_scores(self, get_reock_score):
+        '''
+        '''
+        geometry = unittest.mock.Mock()
+        scores = compactness.get_scores(geometry)
+
+        self.assertEqual(scores['Reock'], get_reock_score.return_value)
+        get_reock_score.assert_called_once_with(geometry)
+    
+    @unittest.mock.patch('planscore.compactness.get_reock_score')
+    def test_get_scores_badgeometry(self, get_reock_score):
+        '''
+        '''
+        get_reock_score.side_effect = raises_exception
+
+        geometry = unittest.mock.Mock()
+        scores = compactness.get_scores(geometry)
+
+        self.assertIsNone(scores['Reock'])
+        get_reock_score.assert_called_once_with(geometry)
     
     def test_reock_score(self):
         ''' Reock score looks about right

--- a/planscore/tests/test_compactness.py
+++ b/planscore/tests/test_compactness.py
@@ -7,18 +7,22 @@ def raises_exception():
 
 class TestCompactness (unittest.TestCase):
 
+    @unittest.mock.patch('planscore.compactness.get_polsbypopper_score')
     @unittest.mock.patch('planscore.compactness.get_reock_score')
-    def test_get_scores(self, get_reock_score):
+    def test_get_scores(self, get_reock_score, get_polsbypopper_score):
         '''
         '''
         geometry = unittest.mock.Mock()
         scores = compactness.get_scores(geometry)
 
         self.assertEqual(scores['Reock'], get_reock_score.return_value)
+        self.assertEqual(scores['Polsby-Popper'], get_polsbypopper_score.return_value)
         get_reock_score.assert_called_once_with(geometry)
+        get_polsbypopper_score.assert_called_once_with(geometry)
     
+    @unittest.mock.patch('planscore.compactness.get_polsbypopper_score')
     @unittest.mock.patch('planscore.compactness.get_reock_score')
-    def test_get_scores_badgeometry(self, get_reock_score):
+    def test_get_scores_bad_reock(self, get_reock_score, get_polsbypopper_score):
         '''
         '''
         get_reock_score.side_effect = raises_exception
@@ -28,6 +32,19 @@ class TestCompactness (unittest.TestCase):
 
         self.assertIsNone(scores['Reock'])
         get_reock_score.assert_called_once_with(geometry)
+    
+    @unittest.mock.patch('planscore.compactness.get_polsbypopper_score')
+    @unittest.mock.patch('planscore.compactness.get_reock_score')
+    def test_get_scores_bad_polsbypopper(self, get_reock_score, get_polsbypopper_score):
+        '''
+        '''
+        get_polsbypopper_score.side_effect = raises_exception
+
+        geometry = unittest.mock.Mock()
+        scores = compactness.get_scores(geometry)
+
+        self.assertIsNone(scores['Polsby-Popper'])
+        get_polsbypopper_score.assert_called_once_with(geometry)
     
     def test_reock_score(self):
         ''' Reock score looks about right
@@ -43,3 +60,18 @@ class TestCompactness (unittest.TestCase):
         # A square around Lake Merritt with a peephole in it
         geom3 = ogr.CreateGeometryFromJson('{"type": "Polygon", "coordinates": [[[-122.2631266, 37.7987797], [-122.2631266, 37.8103489], [-122.2484841, 37.8103489], [-122.2484841, 37.7987797], [-122.2631266, 37.7987797]], [[-122.257189, 37.804124], [-122.257189, 37.804132], [-122.257178, 37.804132], [-122.257178, 37.804124], [-122.257189, 37.804124]]]}')
         self.assertAlmostEqual(compactness.get_reock_score(geom3), 2/math.pi, places=5)
+    
+    def test_polsbypopper_score(self):
+        ''' Polsyby-Popper score looks about right
+        '''
+        # A square around Lake Merritt
+        geom1 = ogr.CreateGeometryFromJson('{"type": "Polygon", "coordinates": [[[-122.2631266, 37.7987797], [-122.2631266, 37.8103489], [-122.2484841, 37.8103489], [-122.2484841, 37.7987797], [-122.2631266, 37.7987797]]]}')
+        self.assertAlmostEqual(compactness.get_polsbypopper_score(geom1), math.pi/4, places=5)
+
+        # A thin line through Lake Merritt
+        geom2 = ogr.CreateGeometryFromJson('{"type": "Polygon", "coordinates": [[[-122.2631266, 37.804111], [-122.2631266, 37.804112], [-122.2484841, 37.804112], [-122.2484841, 37.804111], [-122.2631266, 37.804111]]]}')
+        self.assertAlmostEqual(compactness.get_polsbypopper_score(geom2), 0., places=3)
+
+        # A square around Lake Merritt with a peephole in it
+        geom3 = ogr.CreateGeometryFromJson('{"type": "Polygon", "coordinates": [[[-122.2631266, 37.7987797], [-122.2631266, 37.8103489], [-122.2484841, 37.8103489], [-122.2484841, 37.7987797], [-122.2631266, 37.7987797]], [[-122.257189, 37.804124], [-122.257189, 37.804132], [-122.257178, 37.804132], [-122.257178, 37.804124], [-122.257189, 37.804124]]]}')
+        self.assertAlmostEqual(compactness.get_polsbypopper_score(geom3), math.pi/4, places=2)

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -27,10 +27,11 @@ class TestDistricts (unittest.TestCase):
         storage.s3.get_object.return_value = {'Body': io.BytesIO(b'POINT (0.00001 0.00001)')}
 
         partial = districts.Partial.from_event(dict(index=-1, geometry_key='uploads/0/districts/0.wkt',
-            upload={'id': 'ID', 'key': 'uploads/ID/upload/file.geojson'}), storage)
+            upload={'id': 'ID', 'key': 'uploads/ID/upload/file.geojson'}, compactness={}), storage)
         self.assertEqual(str(partial.geometry), 'POINT (0.00001 0.00001)')
         self.assertEqual(partial.index, -1)
         self.assertEqual(partial.totals, {})
+        self.assertEqual(partial.compactness, {})
         self.assertEqual(partial.precincts, [])
         self.assertEqual(partial.tiles, ['12/2048/2047'])
         self.assertEqual(partial.upload.id, 'ID')
@@ -39,7 +40,8 @@ class TestDistricts (unittest.TestCase):
         ''' Partial.contains_tile() returns correct values.
         '''
         # District partial within the western hemisphere, touching the prime meridian
-        partial = districts.Partial(0, {}, None, None, None, None, ogr.CreateGeometryFromWkt('POLYGON ((0 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,0 -0.0004693,0 0,0 0.0004532))'))
+        partial = districts.Partial(0, {}, None, None, None, None, None,
+            ogr.CreateGeometryFromWkt('POLYGON ((0 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,0 -0.0004693,0 0,0 0.0004532))'))
         
         self.assertTrue(partial.contains_tile('20/524287/524287'),
             'Tiny tile should be contained entirely inside district')
@@ -54,7 +56,8 @@ class TestDistricts (unittest.TestCase):
         ''' Partial.tile_geometry() returns correct geometries.
         '''
         # District partial within the western hemisphere, touching the prime meridian
-        partial = districts.Partial(0, {}, None, None, None, None, ogr.CreateGeometryFromWkt('POLYGON ((0 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,0 -0.0004693,0 0,0 0.0004532))'))
+        partial = districts.Partial(0, {}, None, None, None, None, None,
+            ogr.CreateGeometryFromWkt('POLYGON ((0 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,0 -0.0004693,0 0,0 0.0004532))'))
         
         g1 = partial.tile_geometry('12/2047/2047')
         g2 = partial.tile_geometry('12/2047/2048')
@@ -88,7 +91,7 @@ class TestDistricts (unittest.TestCase):
         storage = unittest.mock.Mock()
         storage.s3.get_object.return_value = {'Body': io.BytesIO(polygon_wkt.encode('utf8'))}
 
-        partial1 = districts.Partial(0, {},
+        partial1 = districts.Partial(0, {}, {'Reock': -1},
             [{"type": "Feature", "properties": {"GEOID": "3", "NAME": "Precinct 3", "Voters": 4, "Red Votes": 3, "Blue Votes": 0, "PlanScore:Fraction": 0.563558429345361}, "geometry": {"type": "Polygon", "coordinates": [[[-0.0003853, 0.0], [-0.0003819, 2.5e-06], [-0.0003824, 1.16e-05], [-0.0003895, 1.16e-05], [-0.000391, 1.47e-05], [-0.0003922, 2.1e-05], [-0.0003832, 3.27e-05], [-0.0003844, 3.81e-05], [-0.0003751, 5.2e-05], [-0.0003683, 5.48e-05], [-0.0003685, 5.99e-05], [-0.0003642, 6.45e-05], [-0.0003597, 6.45e-05], [-0.0003531, 6.45e-05], [-0.0003432, 6.91e-05], [-0.0003379, 6.96e-05], [-0.0003321, 7.06e-05], [-0.0003273, 7.72e-05], [-0.0003268, 8.46e-05], [-0.0003185, 8.97e-05], [-0.0003109, 9.04e-05], [-0.0003064, 9.5e-05], [-0.0002973, 9.45e-05], [-0.0002978, 0.0001047], [-0.0002887, 0.0001103], [-0.0002826, 0.0001067], [-0.0002746, 0.0001042], [-0.0002756, 0.0001164], [-0.0002852, 0.0001179], [-0.0002852, 0.0001245], [-0.0002776, 0.0001291], [-0.0002776, 0.0001438], [-0.0002756, 0.0001464], [-0.00027, 0.0001474], [-0.0002644, 0.0001606], [-0.0002619, 0.0001657], [-0.0002518, 0.0001632], [-0.0002463, 0.0001738], [-0.0002397, 0.0001728], [-0.0002286, 0.0001815], [-0.0002225, 0.0001815], [-0.0002205, 0.0001922], [-0.0002154, 0.0001947], [-0.0002114, 0.0002049], [-0.0001973, 0.0002166], [-0.0001952, 0.0002237], [-0.0001811, 0.0002181], [-0.0001821, 0.000213], [-0.0001882, 0.0002038], [-0.0001856, 0.0001988], [-0.0001856, 0.0001942], [-0.0001882, 0.000184], [-0.0001826, 0.000184], [-0.000176, 0.0001749], [-0.0001715, 0.0001754], [-0.0001634, 0.0001866], [-0.0001594, 0.0001876], [-0.0001538, 0.0001916], [-0.0001478, 0.0001855], [-0.0001382, 0.0001922], [-0.0001255, 0.0001906], [-0.000125, 0.000183], [-0.000118, 0.0001825], [-0.0001175, 0.0001898], [-3.16e-05, 0.0], [-0.0003853, 0.0]]]}}],
             ["whatever"], None, data.Upload('ID', 'key.json'),
             ogr.CreateGeometryFromWkt(polygon_wkt))
@@ -97,6 +100,7 @@ class TestDistricts (unittest.TestCase):
         
         self.assertEqual(partial2.index, partial1.index)
         self.assertEqual(partial2.precincts[0], partial1.precincts[0])
+        self.assertEqual(partial2.compactness['Reock'], partial1.compactness['Reock'])
         self.assertEqual(partial2.tiles, partial1.tiles)
         self.assertEqual(str(partial2.geometry_key), str(partial1.geometry_key))
     
@@ -193,7 +197,7 @@ class TestDistricts (unittest.TestCase):
         event = {'index': -1, 'bucket': 'bucket-name', 'totals': {},
             'precincts': [{'Totals': 1}], 'tiles': ['12/2047/2048'],
             'upload': {'id': 'ID', 'key': 'uploads/ID/upload/file.geojson'},
-            'geometry_key': 'geom.wkt'}
+            'geometry_key': 'geom.wkt', 'compactness': {}}
 
         districts.lambda_handler(event, None)
         storage, partial = consume_tiles.mock_calls[0][1]
@@ -246,7 +250,7 @@ class TestDistricts (unittest.TestCase):
     def test_post_score_results(self, stdout):
         ''' Expected results are posted to S3.
         '''
-        partial = districts.Partial(-1, {"Voters": 1}, [], [], 'uploads/ID/geometries/-1.wkt',
+        partial = districts.Partial(-1, {"Voters": 1}, {}, [], [], 'uploads/ID/geometries/-1.wkt',
             data.Upload('ID', 'uploads/ID/upload/file.geojson', districts=[None, None]), None)
         
         # First time through, there's only one district noted on the server
@@ -261,7 +265,7 @@ class TestDistricts (unittest.TestCase):
         #    Bucket='bucket-name', Prefix='uploads/ID/districts')
 
         storage.s3.put_object.assert_called_once_with(
-            ACL='private', Body=b'{"totals": {"Voters": 1}, "geometry_key": "uploads/ID/geometries/-1.wkt"}',
+            ACL='private', Body=b'{\n  "totals": {\n    "Voters": 1\n  }\n}',
             Bucket='bucket-name', ContentType='text/json', Key='uploads/ID/districts/-1.json')
         
         # Second time through, both expected districts are there
@@ -293,7 +297,7 @@ class TestDistricts (unittest.TestCase):
         score_precinct.side_effect = mock_score_precinct
         
         for (index, (totals, precincts, tiles)) in enumerate(cases):
-            partial = districts.Partial(-1, totals, precincts, tiles, None, None, None)
+            partial = districts.Partial(-1, totals, None, precincts, tiles, None, None, None)
             iterations = list(districts.consume_tiles(None, partial))
             self.assertFalse(partial.precincts, 'Precincts should be completely emptied ({})'.format(index))
             self.assertFalse(partial.tiles, 'Tiles should be completely emptied ({})'.format(index))
@@ -318,7 +322,7 @@ class TestDistricts (unittest.TestCase):
             [({'Voters': 2}, ), ({'Voters': 4}, {'Voters': 8})]
         
         upload = data.Upload('ID', None)
-        partial = districts.Partial(-1, totals, precincts, tiles, None, upload, None)
+        partial = districts.Partial(-1, totals, None, precincts, tiles, None, upload, None)
         call = districts.consume_tiles(None, partial)
         self.assertEqual((partial.index, partial.totals, partial.precincts, partial.tiles, partial.upload.id),
             (-1, {'Voters': 0}, [{'Voters': 1}], [({'Voters': 2}, ), ({'Voters': 4}, {'Voters': 8})], 'ID'),
@@ -348,7 +352,7 @@ class TestDistricts (unittest.TestCase):
         totals = {"Voters": 0, "Red Votes": 0, "REP999": 0, "Blue Votes": 0, "DEM999": 0}
         geometry = ogr.CreateGeometryFromWkt('POLYGON ((-0.0002360 0.0004532,-0.0006812 0.0002467,-0.0006356 -0.0003486,-0.0000268 -0.0004693,-0.0000187 -0.0000214,-0.0002360 0.0004532))')
         precinct = {"type": "Feature", "properties": {"GEOID": "3", "NAME": "Precinct 3", "Voters": 4, "Red Votes": 3, "REP999": 3, "Blue Votes": 0, "DEM999": 0, "PlanScore:Fraction": 0.563558429345361}, "geometry": {"type": "Polygon", "coordinates": [[[-0.0003853, 0.0], [-0.0003819, 2.5e-06], [-0.0003824, 1.16e-05], [-0.0003895, 1.16e-05], [-0.000391, 1.47e-05], [-0.0003922, 2.1e-05], [-0.0003832, 3.27e-05], [-0.0003844, 3.81e-05], [-0.0003751, 5.2e-05], [-0.0003683, 5.48e-05], [-0.0003685, 5.99e-05], [-0.0003642, 6.45e-05], [-0.0003597, 6.45e-05], [-0.0003531, 6.45e-05], [-0.0003432, 6.91e-05], [-0.0003379, 6.96e-05], [-0.0003321, 7.06e-05], [-0.0003273, 7.72e-05], [-0.0003268, 8.46e-05], [-0.0003185, 8.97e-05], [-0.0003109, 9.04e-05], [-0.0003064, 9.5e-05], [-0.0002973, 9.45e-05], [-0.0002978, 0.0001047], [-0.0002887, 0.0001103], [-0.0002826, 0.0001067], [-0.0002746, 0.0001042], [-0.0002756, 0.0001164], [-0.0002852, 0.0001179], [-0.0002852, 0.0001245], [-0.0002776, 0.0001291], [-0.0002776, 0.0001438], [-0.0002756, 0.0001464], [-0.00027, 0.0001474], [-0.0002644, 0.0001606], [-0.0002619, 0.0001657], [-0.0002518, 0.0001632], [-0.0002463, 0.0001738], [-0.0002397, 0.0001728], [-0.0002286, 0.0001815], [-0.0002225, 0.0001815], [-0.0002205, 0.0001922], [-0.0002154, 0.0001947], [-0.0002114, 0.0002049], [-0.0001973, 0.0002166], [-0.0001952, 0.0002237], [-0.0001811, 0.0002181], [-0.0001821, 0.000213], [-0.0001882, 0.0002038], [-0.0001856, 0.0001988], [-0.0001856, 0.0001942], [-0.0001882, 0.000184], [-0.0001826, 0.000184], [-0.000176, 0.0001749], [-0.0001715, 0.0001754], [-0.0001634, 0.0001866], [-0.0001594, 0.0001876], [-0.0001538, 0.0001916], [-0.0001478, 0.0001855], [-0.0001382, 0.0001922], [-0.0001255, 0.0001906], [-0.000125, 0.000183], [-0.000118, 0.0001825], [-0.0001175, 0.0001898], [-3.16e-05, 0.0], [-0.0003853, 0.0]]]}}
-        partial = districts.Partial(None, totals, None, None, None, None, geometry)
+        partial = districts.Partial(None, totals, None, None, None, None, None, geometry)
         
         # Check each overlapping tile
         for tile_zxy in ('12/2047/2047', '12/2047/2048', '12/2048/2047', '12/2048/2048'):
@@ -379,7 +383,7 @@ class TestDistricts (unittest.TestCase):
         ''' Correct voter count for a precinct from tile within district.
         '''
         geometry = ogr.CreateGeometryFromWkt('POLYGON ((-1 -1,-1 1,1 1,1 -1,-1 -1))')
-        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, geometry)
+        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, None, geometry)
         self.assertTrue(partial.contains_tile('12/2048/2047'))
 
         precinct = {"type": "Feature", "properties": {"Voters": 1, "PlanScore:Fraction": 0.5}, "geometry": {"type": "Polygon", "coordinates": [[[.02, .02], [.02, .06], [.06, .06], [.06, .02], [.02, .02]]]}}
@@ -390,7 +394,7 @@ class TestDistricts (unittest.TestCase):
         ''' Correct voter count for a precinct within district from tile overlapping district.
         '''
         geometry = ogr.CreateGeometryFromWkt('POLYGON ((-1 -1,-1 1,0.17 1,0.17 -1,-1 -1))')
-        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, geometry)
+        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, None, geometry)
         self.assertFalse(partial.contains_tile('12/2049/2046'))
 
         precinct = {"type": "Feature", "properties": {"Voters": 1, "PlanScore:Fraction": 0.5}, "geometry": {"type": "Polygon", "coordinates": [[[.12, .12], [.12, .16], [.16, .16], [.16, .12], [.12, .12]]]}}
@@ -401,7 +405,7 @@ class TestDistricts (unittest.TestCase):
         ''' Correct voter count for a precinct overlapping district from tile overlapping district.
         '''
         geometry = ogr.CreateGeometryFromWkt('POLYGON ((-1 -1,-1 1,0.14 1,0.14 -1,-1 -1))')
-        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, geometry)
+        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, None, geometry)
         self.assertFalse(partial.contains_tile('12/2049/2046'))
 
         precinct = {"type": "Feature", "properties": {"Voters": 1, "PlanScore:Fraction": 0.5}, "geometry": {"type": "Polygon", "coordinates": [[[.12, .12], [.12, .16], [.16, .16], [.16, .12], [.12, .12]]]}}
@@ -412,7 +416,7 @@ class TestDistricts (unittest.TestCase):
         ''' Correct voter count for a precinct touching district from tile overlapping district.
         '''
         geometry = ogr.CreateGeometryFromWkt('POLYGON ((-1 -1,-1 1,0.12 1,0.12 -1,-1 -1))')
-        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, geometry)
+        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, None, geometry)
         self.assertFalse(partial.contains_tile('12/2049/2046'))
 
         precinct = {"type": "Feature", "properties": {"Voters": 1, "PlanScore:Fraction": 0.5}, "geometry": {"type": "Polygon", "coordinates": [[[.12, .12], [.12, .16], [.16, .16], [.16, .12], [.12, .12]]]}}
@@ -423,7 +427,7 @@ class TestDistricts (unittest.TestCase):
         ''' Correct voter count for a precinct outside district from tile overlapping district.
         '''
         geometry = ogr.CreateGeometryFromWkt('POLYGON ((-1 -1,-1 1,0.11 1,0.11 -1,-1 -1))')
-        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, geometry)
+        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, None, geometry)
         self.assertFalse(partial.contains_tile('12/2049/2046'))
 
         precinct = {"type": "Feature", "properties": {"Voters": 1, "PlanScore:Fraction": 0.5}, "geometry": {"type": "Polygon", "coordinates": [[[.12, .12], [.12, .16], [.16, .16], [.16, .12], [.12, .12]]]}}
@@ -434,7 +438,7 @@ class TestDistricts (unittest.TestCase):
         ''' Correct voter count for a block-point within district from tile overlapping district.
         '''
         geometry = ogr.CreateGeometryFromWkt('POLYGON ((-1 -1,-1 1,0.17 1,0.17 -1,-1 -1))')
-        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, geometry)
+        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, None, geometry)
         self.assertFalse(partial.contains_tile('12/2049/2046'))
 
         blockpoint = {"type": "Feature", "properties": {"Voters": 1}, "geometry": {"type": "Point", "coordinates": [.14, .14]}}
@@ -445,7 +449,7 @@ class TestDistricts (unittest.TestCase):
         ''' Correct voter count for a block-point outside district from tile overlapping district.
         '''
         geometry = ogr.CreateGeometryFromWkt('POLYGON ((-1 -1,-1 1,0.11 1,0.11 -1,-1 -1))')
-        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, geometry)
+        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, None, geometry)
         self.assertFalse(partial.contains_tile('12/2049/2046'))
 
         blockpoint = {"type": "Feature", "properties": {"Voters": 1}, "geometry": {"type": "Point", "coordinates": [.14, .14]}}
@@ -456,7 +460,7 @@ class TestDistricts (unittest.TestCase):
         ''' Correct voter count for a precinct from tile touching district.
         '''
         geometry = ogr.CreateGeometryFromWkt('POLYGON ((-1 -1,-1 1,0.087890625 1,0.087890625 -1,-1 -1))')
-        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, geometry)
+        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, None, geometry)
         self.assertFalse(partial.contains_tile('12/2049/2046'))
 
         precinct = {"type": "Feature", "properties": {"Voters": 1, "PlanScore:Fraction": 0.5}, "geometry": {"type": "Polygon", "coordinates": [[[.12, .12], [.12, .16], [.16, .16], [.16, .12], [.12, .12]]]}}
@@ -467,7 +471,7 @@ class TestDistricts (unittest.TestCase):
         ''' Correct voter count for a precinct from tile outside district.
         '''
         geometry = ogr.CreateGeometryFromWkt('POLYGON ((-1 -1,-1 1,1 1,1 -1,-1 -1))')
-        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, geometry)
+        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, None, geometry)
         self.assertFalse(partial.contains_tile('12/2059/2047'))
 
         precinct = {"type": "Feature", "properties": {"Voters": 1, "PlanScore:Fraction": 0.5}, "geometry": {"type": "Polygon", "coordinates": [[[.02, .02], [.02, .06], [.06, .06], [.06, .02], [.02, .02]]]}}
@@ -478,7 +482,7 @@ class TestDistricts (unittest.TestCase):
         ''' Correct voter count for a block-point from tile within district.
         '''
         geometry = ogr.CreateGeometryFromWkt('POLYGON ((-1 -1,-1 1,1 1,1 -1,-1 -1))')
-        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, geometry)
+        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, None, geometry)
         self.assertTrue(partial.contains_tile('12/2048/2047'))
 
         blockpoint = {"type": "Feature", "properties": {"Voters": 1}, "geometry": {"type": "Point", "coordinates": [.04, .04]}}
@@ -489,7 +493,7 @@ class TestDistricts (unittest.TestCase):
         ''' Correct voter count for a block-point from tile outside district.
         '''
         geometry = ogr.CreateGeometryFromWkt('POLYGON ((-1 -1,-1 1,1 1,1 -1,-1 -1))')
-        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, geometry)
+        partial = districts.Partial(None, {'Voters': 0}, None, None, None, None, None, geometry)
         self.assertFalse(partial.contains_tile('12/2059/2047'))
 
         blockpoint = {"type": "Feature", "properties": {"Voters": 1}, "geometry": {"type": "Point", "coordinates": [1.00, 0.05]}}

--- a/planscore/tests/test_smallestenclosingcircle.py
+++ b/planscore/tests/test_smallestenclosingcircle.py
@@ -1,0 +1,133 @@
+# 
+# Smallest enclosing circle - Test suite (Python)
+# 
+# Copyright (c) 2017 Project Nayuki
+# https://www.nayuki.io/page/smallest-enclosing-circle
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+# 
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program (see COPYING.txt and COPYING.LESSER.txt).
+# If not, see <http://www.gnu.org/licenses/>.
+# 
+
+import random, unittest, os
+from ..compactness import smallestenclosingcircle
+
+# Only run lots of time-consuming trials in CI
+many_trials =  bool(os.environ.get('CI') == 'true')
+
+
+# ---- Test suite functions ----
+
+class SmallestEnclosingCircleTest(unittest.TestCase):
+	
+	def test_matching_naive_algorithm(self):
+		TRIALS = 1000 if many_trials else 10
+		for _ in range(TRIALS):
+			points = _make_random_points(random.randint(1, 30))
+			reference = _smallest_enclosing_circle_naive(points)
+			actual = smallestenclosingcircle.make_circle(points)
+			self.assertAlmostEqual(actual[0], reference[0], delta=_EPSILON)
+			self.assertAlmostEqual(actual[1], reference[1], delta=_EPSILON)
+			self.assertAlmostEqual(actual[2], reference[2], delta=_EPSILON)
+	
+	
+	def test_translation(self):
+		TRIALS = 100 if many_trials else 10
+		CHECKS = 10
+		for _ in range(TRIALS):
+			points = _make_random_points(random.randint(1, 300))
+			reference = smallestenclosingcircle.make_circle(points)
+			
+			for _ in range(CHECKS):
+				dx = random.gauss(0, 1)
+				dy = random.gauss(0, 1)
+				newpoints = [(x + dx, y + dy) for (x, y) in points]
+				
+				translated = smallestenclosingcircle.make_circle(newpoints)
+				self.assertAlmostEqual(translated[0], reference[0] + dx, delta=_EPSILON)
+				self.assertAlmostEqual(translated[1], reference[1] + dy, delta=_EPSILON)
+				self.assertAlmostEqual(translated[2], reference[2]     , delta=_EPSILON)
+	
+	
+	def test_scaling(self):
+		TRIALS = 100 if many_trials else 10
+		CHECKS = 10
+		for _ in range(TRIALS):
+			points = _make_random_points(random.randint(1, 300))
+			reference = smallestenclosingcircle.make_circle(points)
+			
+			for _ in range(CHECKS):
+				scale = random.gauss(0, 1)
+				newpoints = [(x * scale, y * scale) for (x, y) in points]
+				
+				scaled = smallestenclosingcircle.make_circle(newpoints)
+				self.assertAlmostEqual(scaled[0], reference[0] * scale     , delta=_EPSILON)
+				self.assertAlmostEqual(scaled[1], reference[1] * scale     , delta=_EPSILON)
+				self.assertAlmostEqual(scaled[2], reference[2] * abs(scale), delta=_EPSILON)
+
+
+
+# ---- Helper functions ----
+
+def _make_random_points(n):
+	if random.random() < 0.2:  # Discrete lattice (to have a chance of duplicated points)
+		return [(random.randrange(10), random.randrange(10)) for _ in range(n)]
+	else:  # Gaussian distribution
+		return [(random.gauss(0, 1), random.gauss(0, 1)) for _ in range(n)]
+
+
+# Returns the smallest enclosing circle in O(n^4) time using the naive algorithm.
+def _smallest_enclosing_circle_naive(points):
+	# Degenerate cases
+	if len(points) == 0:
+		return None
+	elif len(points) == 1:
+		return (points[0][0], points[0][1], 0)
+	
+	# Try all unique pairs
+	result = None
+	for i in range(len(points)):
+		p = points[i]
+		for j in range(i + 1, len(points)):
+			q = points[j]
+			c = smallestenclosingcircle.make_diameter(p, q)
+			if (result is None or c[2] < result[2]) and \
+					all(smallestenclosingcircle.is_in_circle(c, r) for r in points):
+				result = c
+	if result is not None:
+		return result  # This optimization is not mathematically proven
+	
+	# Try all unique triples
+	for i in range(len(points)):
+		p = points[i]
+		for j in range(i + 1, len(points)):
+			q = points[j]
+			for k in range(j + 1, len(points)):
+				r = points[k]
+				c = smallestenclosingcircle.make_circumcircle(p, q, r)
+				if c is not None and (result is None or c[2] < result[2]) and \
+						all(smallestenclosingcircle.is_in_circle(c, s) for s in points):
+					result = c
+	
+	if result is None:
+		raise AssertionError()
+	return result
+
+
+_EPSILON = 1e-12
+
+
+# ---- Main runner ----
+
+if __name__ == "__main__":
+	unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,9 @@ setup(
     url = 'https://github.com/migurski/PlanScore',
     author = 'Michal Migurski',
     description = '',
-    packages = ['planscore', 'planscore.website', 'planscore.tests'],
+    packages = [
+        'planscore', 'planscore.website', 'planscore.tests', 'planscore.compactness'
+        ],
     test_suite = 'planscore.tests',
     package_data = {
         'planscore': ['geodata/*.*'],


### PR DESCRIPTION
Using definitions from https://github.com/cicero-data/compactness-stats/wiki and @nayuki’s implementation of smallest bounding circle. Scores appear under `compactness` in index JSON.