### PR TITLE
Add Mean/Median calculation to output

### DIFF
--- a/planscore/score.py
+++ b/planscore/score.py
@@ -76,6 +76,17 @@ def calculate_EG(red_districts, blue_districts, vote_swing=0):
     
     return (wasted_red - wasted_blue) / election_votes
 
+def calculate_MMD(red_districts, blue_districts):
+    ''' Convert two lists of district vote counts into a Mean/Median score.
+    
+        Vote swing does not seem to affect Mean/Median, so leave it off.
+    '''
+    shares = sorted([B/(R + B) for (R, B) in zip(red_districts, blue_districts)])
+    median = shares[len(shares)//2]
+    mean = statistics.mean(shares)
+    
+    return median - mean
+
 def calculate_gap(upload):
     '''
     '''

--- a/planscore/score.py
+++ b/planscore/score.py
@@ -87,8 +87,8 @@ def calculate_MMD(red_districts, blue_districts):
     
     return median - mean
 
-def calculate_gap(upload):
-    '''
+def calculate_bias(upload):
+    ''' Calculate partisan metrics for districts with plain vote counts.
     '''
     summary_dict, gaps = {}, {
         'Red/Blue': ('Red Votes', 'Blue Votes'),
@@ -107,6 +107,7 @@ def calculate_gap(upload):
         blue_districts = [d['totals'].get(blue_field) or 0 for d in upload.districts]
 
         if prefix == 'Red/Blue':
+            summary_dict['Mean/Median'] = calculate_MMD(red_districts, blue_districts)
             summary_dict['Efficiency Gap'] = calculate_EG(red_districts, blue_districts)
 
             # Calculate -5 to +5 point swings
@@ -115,6 +116,7 @@ def calculate_gap(upload):
                 gap = calculate_EG(red_districts, blue_districts, swing * points)
                 summary_dict[f'Efficiency Gap +{points:.0f} {party}'] = gap
         else:
+            summary_dict[f'{prefix} Mean/Median'] = calculate_MMD(red_districts, blue_districts)
             summary_dict[f'{prefix} Efficiency Gap'] = calculate_EG(red_districts, blue_districts)
 
             # Calculate -5 to +5 point swings
@@ -125,9 +127,10 @@ def calculate_gap(upload):
     
     return upload.clone(summary=summary_dict)
 
-def calculate_gaps(upload):
+def calculate_biases(upload):
+    ''' Calculate partisan metrics for districts with multiple simulations.
     '''
-    '''
+    MMDs = list()
     EGs = {swing: list() for swing in (0, 1, -1, 2, -2, 3, -3, 4, -4, 5, -5)}
     summary_dict, copied_districts = dict(), copy.deepcopy(upload.districts)
     first_totals = copied_districts[0]['totals']
@@ -154,6 +157,8 @@ def calculate_gaps(upload):
             all_red_districts[i].append(red_votes)
             all_blue_districts[i].append(blue_votes)
     
+        MMDs.append(calculate_MMD(sim_red_districts, sim_blue_districts))
+        
         for swing in EGs:
             EGs[swing].append(calculate_EG(sim_red_districts, sim_blue_districts, swing/100))
     
@@ -165,6 +170,8 @@ def calculate_gaps(upload):
         district['totals']['Democratic Votes SD'] = statistics.stdev(blue_votes)
         district['totals']['Republican Votes SD'] = statistics.stdev(red_votes)
 
+    summary_dict['Mean/Median'] = statistics.mean(MMDs)
+    summary_dict['Mean/Median SD'] = statistics.stdev(MMDs)
     summary_dict['Efficiency Gap'] = statistics.mean(EGs[0])
     summary_dict['Efficiency Gap SD'] = statistics.stdev(EGs[0])
     
@@ -237,8 +244,8 @@ def combine_district_scores(storage, input_upload):
         
         new_districts.append(new_district)
 
-    interim_upload = calculate_gap(input_upload.clone(districts=new_districts))
-    output_upload = calculate_gaps(interim_upload)
+    interim_upload = calculate_bias(input_upload.clone(districts=new_districts))
+    output_upload = calculate_biases(interim_upload)
     put_upload_index(storage.s3, storage.bucket, output_upload)
 
 def lambda_handler(event, context):

--- a/planscore/tests/test_score.py
+++ b/planscore/tests/test_score.py
@@ -52,6 +52,29 @@ class TestScore (unittest.TestCase):
 
         gap4 = score.calculate_EG((1, 5, 5, 5), (7, 3, 3, 3), 0)
         self.assertAlmostEqual(gap4, gap1, msg='Should see identical EG with unchanged vote swing')
+    
+    def test_calculate_MMD(self):
+        ''' Mean/Median can be correctly calculated for various elections
+        '''
+        mmd1 = score.calculate_MMD((6, 6, 4, 4, 4), (5, 5, 5, 8, 8))
+        self.assertAlmostEqual(mmd1, 0, places=2,
+            msg='Should see zero MMD with 44% mean and 44% median red vote share')
+
+        mmd2 = score.calculate_MMD((6, 6, 6, 6, 6), (4, 4, 4, 4, 4))
+        self.assertAlmostEqual(mmd2, 0, places=2,
+            msg='Should see zero MMD with 60% mean and 60% median red vote share')
+
+        mmd3 = score.calculate_MMD((6, 6, 6, 1, 1), (5, 5, 5, 10, 10))
+        self.assertAlmostEqual(mmd3, -.18, places=2,
+            msg='Should see +red MMD with 36% mean and 54% median red vote share')
+
+        mmd4 = score.calculate_MMD((6, 6, 6, 6, 1), (5, 5, 5, 5, 10))
+        self.assertAlmostEqual(mmd4, -.09, places=2,
+            msg='Should see +red MMD with 45% mean and 54% median red vote share')
+
+        mmd5 = score.calculate_MMD((6, 6, 1, 1, 1), (5, 5, 7, 10, 10))
+        self.assertAlmostEqual(mmd5, .15, places=2,
+            msg='Should see +blue MMD with 28% mean and 13% median red vote share')
 
     @unittest.mock.patch('planscore.score.calculate_EG')
     def test_calculate_gap(self, calculate_EG):

--- a/planscore/tests/test_score.py
+++ b/planscore/tests/test_score.py
@@ -76,8 +76,9 @@ class TestScore (unittest.TestCase):
         self.assertAlmostEqual(mmd5, .15, places=2,
             msg='Should see +blue MMD with 28% mean and 13% median red vote share')
 
+    @unittest.mock.patch('planscore.score.calculate_MMD')
     @unittest.mock.patch('planscore.score.calculate_EG')
-    def test_calculate_gap(self, calculate_EG):
+    def test_calculate_bias(self, calculate_EG, calculate_MMD):
         ''' Efficiency gap can be correctly calculated for an election
         '''
         input = data.Upload(id=None, key=None,
@@ -88,7 +89,10 @@ class TestScore (unittest.TestCase):
                 dict(totals={'Voters': 10, 'Red Votes': 6, 'Blue Votes': 2}, tile=None),
                 ])
         
-        output = score.calculate_gaps(score.calculate_gap(input))
+        output = score.calculate_biases(score.calculate_bias(input))
+
+        self.assertEqual(output.summary['Mean/Median'], calculate_MMD.return_value)
+        self.assertEqual(calculate_MMD.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2]))
 
         self.assertEqual(output.summary['Efficiency Gap'], calculate_EG.return_value)
         self.assertEqual(calculate_EG.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2]))
@@ -99,8 +103,9 @@ class TestScore (unittest.TestCase):
         self.assertEqual(output.summary['Efficiency Gap +1 Red'], calculate_EG.return_value)
         self.assertEqual(calculate_EG.mock_calls[2][1], ([2, 3, 5, 6], [6, 5, 3, 2], -.01))
 
+    @unittest.mock.patch('planscore.score.calculate_MMD')
     @unittest.mock.patch('planscore.score.calculate_EG')
-    def test_calculate_gap_ushouse(self, calculate_EG):
+    def test_calculate_gap_ushouse(self, calculate_EG, calculate_MMD):
         ''' Efficiency gap can be correctly calculated for a U.S. House election
         '''
         input = data.Upload(id=None, key=None,
@@ -111,7 +116,10 @@ class TestScore (unittest.TestCase):
                 dict(totals={'US House Rep Votes': 6, 'US House Dem Votes': 2}, tile=None),
                 ])
         
-        output = score.calculate_gaps(score.calculate_gap(input))
+        output = score.calculate_biases(score.calculate_bias(input))
+
+        self.assertEqual(output.summary['US House Mean/Median'], calculate_MMD.return_value)
+        self.assertEqual(calculate_MMD.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2]))
 
         self.assertEqual(output.summary['US House Efficiency Gap'], calculate_EG.return_value)
         self.assertEqual(calculate_EG.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2]))
@@ -122,8 +130,9 @@ class TestScore (unittest.TestCase):
         self.assertEqual(output.summary['US House Efficiency Gap +1 Rep'], calculate_EG.return_value)
         self.assertEqual(calculate_EG.mock_calls[2][1], ([2, 3, 5, 6], [6, 5, 3, 2], -.01))
 
+    @unittest.mock.patch('planscore.score.calculate_MMD')
     @unittest.mock.patch('planscore.score.calculate_EG')
-    def test_calculate_gap_upperhouse(self, calculate_EG):
+    def test_calculate_gap_upperhouse(self, calculate_EG, calculate_MMD):
         ''' Efficiency gap can be correctly calculated for a State upper house election
         '''
         input = data.Upload(id=None, key=None,
@@ -134,7 +143,10 @@ class TestScore (unittest.TestCase):
                 dict(totals={'SLDU Rep Votes': 6, 'SLDU Dem Votes': 2}, tile=None),
                 ])
         
-        output = score.calculate_gaps(score.calculate_gap(input))
+        output = score.calculate_biases(score.calculate_bias(input))
+
+        self.assertEqual(output.summary['SLDU Mean/Median'], calculate_MMD.return_value)
+        self.assertEqual(calculate_MMD.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2]))
 
         self.assertEqual(output.summary['SLDU Efficiency Gap'], calculate_EG.return_value)
         self.assertEqual(calculate_EG.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2]))
@@ -145,8 +157,9 @@ class TestScore (unittest.TestCase):
         self.assertEqual(output.summary['SLDU Efficiency Gap +1 Rep'], calculate_EG.return_value)
         self.assertEqual(calculate_EG.mock_calls[2][1], ([2, 3, 5, 6], [6, 5, 3, 2], -.01))
 
+    @unittest.mock.patch('planscore.score.calculate_MMD')
     @unittest.mock.patch('planscore.score.calculate_EG')
-    def test_calculate_gap_lowerhouse(self, calculate_EG):
+    def test_calculate_gap_lowerhouse(self, calculate_EG, calculate_MMD):
         ''' Efficiency gap can be correctly calculated for a State lower house election
         '''
         input = data.Upload(id=None, key=None,
@@ -157,7 +170,10 @@ class TestScore (unittest.TestCase):
                 dict(totals={'SLDL Rep Votes': 6, 'SLDL Dem Votes': 2}, tile=None),
                 ])
         
-        output = score.calculate_gaps(score.calculate_gap(input))
+        output = score.calculate_biases(score.calculate_bias(input))
+
+        self.assertEqual(output.summary['SLDL Mean/Median'], calculate_MMD.return_value)
+        self.assertEqual(calculate_MMD.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2]))
 
         self.assertEqual(output.summary['SLDL Efficiency Gap'], calculate_EG.return_value)
         self.assertEqual(calculate_EG.mock_calls[0][1], ([2, 3, 5, 6], [6, 5, 3, 2]))
@@ -168,8 +184,9 @@ class TestScore (unittest.TestCase):
         self.assertEqual(output.summary['SLDL Efficiency Gap +1 Rep'], calculate_EG.return_value)
         self.assertEqual(calculate_EG.mock_calls[2][1], ([2, 3, 5, 6], [6, 5, 3, 2], -.01))
 
+    @unittest.mock.patch('planscore.score.calculate_MMD')
     @unittest.mock.patch('planscore.score.calculate_EG')
-    def test_calculate_gap_sims(self, calculate_EG):
+    def test_calculate_gap_sims(self, calculate_EG, calculate_MMD):
         ''' Efficiency gap can be correctly calculated using input sims.
         '''
         input = data.Upload(id=None, key=None,
@@ -180,8 +197,11 @@ class TestScore (unittest.TestCase):
                 dict(totals={"REP000": 6, "DEM000": 2, "REP001": 5, "DEM001": 3}, tile=None),
                 ])
         
+        calculate_MMD.return_value = 0
         calculate_EG.return_value = 0
-        output = score.calculate_gaps(score.calculate_gap(input))
+        output = score.calculate_biases(score.calculate_bias(input))
+        self.assertEqual(output.summary['Mean/Median'], calculate_MMD.return_value)
+        self.assertEqual(output.summary['Mean/Median SD'], 0)
         self.assertEqual(output.summary['Efficiency Gap'], calculate_EG.return_value)
         self.assertEqual(output.summary['Efficiency Gap SD'], 0)
         self.assertIn('Efficiency Gap +1 Dem', output.summary)
@@ -252,10 +272,10 @@ class TestScore (unittest.TestCase):
         self.assertTrue(completeness.is_complete(), 'Should see accurate return from district_completeness()')
     
     @unittest.mock.patch('sys.stdout')
-    @unittest.mock.patch('planscore.score.calculate_gaps')
-    @unittest.mock.patch('planscore.score.calculate_gap')
+    @unittest.mock.patch('planscore.score.calculate_biases')
+    @unittest.mock.patch('planscore.score.calculate_bias')
     @unittest.mock.patch('planscore.score.put_upload_index')
-    def test_combine_district_scores(self, put_upload_index, calculate_gap, calculate_gaps, stdout):
+    def test_combine_district_scores(self, put_upload_index, calculate_bias, calculate_biases, stdout):
         '''
         '''
         storage = unittest.mock.Mock()
@@ -276,7 +296,7 @@ class TestScore (unittest.TestCase):
         
         self.assertEqual(len(storage.s3.get_object.mock_calls), 2, 'Should have asked for each district in turn')
         
-        input_upload = calculate_gap.mock_calls[0][1][0]
+        input_upload = calculate_bias.mock_calls[0][1][0]
         self.assertEqual(input_upload.id, 'sample-plan')
         self.assertEqual(len(input_upload.districts), 2)
         self.assertIn('totals', input_upload.districts[0])
@@ -286,10 +306,10 @@ class TestScore (unittest.TestCase):
         self.assertEqual(input_upload.districts[0]['compactness']['Reock'], 0.58986716)
         self.assertEqual(input_upload.districts[1]['compactness']['Reock'], 0.53540118)
         
-        interim_upload = calculate_gap.return_value
-        calculate_gaps.assert_called_once_with(interim_upload)
+        interim_upload = calculate_bias.return_value
+        calculate_biases.assert_called_once_with(interim_upload)
         
-        output_upload = calculate_gaps.return_value
+        output_upload = calculate_biases.return_value
         put_upload_index.assert_called_once_with(storage.s3, 'bucket-name', output_upload)
     
     @unittest.mock.patch('sys.stdout')


### PR DESCRIPTION
MMD is another useful partisan symmetry metric. It doesn’t seem to have the same sensitivity to vote swings so just include a single value.