### PR TITLE
Replaced ACL=private with ACL=bucket-owner-full-control

### DIFF
--- a/planscore/after_upload.py
+++ b/planscore/after_upload.py
@@ -74,7 +74,7 @@ def put_district_geometries(s3, bucket, upload, path):
         
         key = data.UPLOAD_GEOMETRIES_KEY.format(id=upload.id, index=index)
         
-        s3.put_object(Bucket=bucket, Key=key,
+        s3.put_object(Bucket=bucket, Key=key, ACL='bucket-owner-full-control',
             Body=geometry.ExportToWkt(), ContentType='text/plain')
         
         keys.append(key)

--- a/planscore/districts.py
+++ b/planscore/districts.py
@@ -176,7 +176,7 @@ def post_score_results(storage, partial):
     print('Uploading', len(body), 'bytes to', key)
     
     storage.s3.put_object(Bucket=storage.bucket, Key=key, Body=body,
-        ContentType='text/json', ACL='private')
+        ContentType='text/json', ACL='bucket-owner-full-control')
 
 def consume_tiles(storage, partial):
     ''' Generate a stream of steps, updating totals from precincts and tiles.

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -273,7 +273,7 @@ class TestDistricts (unittest.TestCase):
         districts.post_score_results(storage, partial)
 
         storage.s3.put_object.assert_called_once_with(
-            ACL='private', Body=b'{\n  "index": -1,\n  "totals": {\n    "Voters": 1\n  },\n  "compactness": {},\n  "precincts": 0,\n  "tiles": [],\n  "upload": {\n    "id": "ID",\n    "key": "uploads/ID/upload/file.geojson",\n    "districts": [\n      null,\n      null\n    ],\n    "summary": {},\n    "progress": null,\n    "start_time": -1\n  }\n}',
+            ACL='bucket-owner-full-control', Body=b'{\n  "index": -1,\n  "totals": {\n    "Voters": 1\n  },\n  "compactness": {},\n  "precincts": 0,\n  "tiles": [],\n  "upload": {\n    "id": "ID",\n    "key": "uploads/ID/upload/file.geojson",\n    "districts": [\n      null,\n      null\n    ],\n    "summary": {},\n    "progress": null,\n    "start_time": -1\n  }\n}',
             Bucket='bucket-name', ContentType='text/json', Key='uploads/ID/districts/-1.json')
     
     @unittest.mock.patch('planscore.districts.load_tile_precincts')

--- a/planscore/tests/test_upload_fields.py
+++ b/planscore/tests/test_upload_fields.py
@@ -44,7 +44,7 @@ class TestUploadFields (unittest.TestCase):
         url, fields = upload_fields.get_upload_fields(s3, creds, 'https://example.org', 'sec')
         
         s3.generate_presigned_post.assert_called_once_with('the-bucket',
-            'uploads/id/upload/${filename}', Conditions=[{'acl': 'private'},
+            'uploads/id/upload/${filename}', Conditions=[{'acl': 'bucket-owner-full-control'},
             {'success_action_redirect': 'https://example.org/uploaded?id=id.sig'},
             ['starts-with', '$key', 'uploads/id/upload/']], ExpiresIn=300)
 
@@ -62,7 +62,7 @@ class TestUploadFields (unittest.TestCase):
         url, fields = upload_fields.get_upload_fields(s3, creds, 'https://example.org', 'sec')
         
         s3.generate_presigned_post.assert_called_once_with('the-bucket',
-            'uploads/id/upload/${filename}', Conditions=[{'acl': 'private'},
+            'uploads/id/upload/${filename}', Conditions=[{'acl': 'bucket-owner-full-control'},
             {'success_action_redirect': 'https://example.org/uploaded?id=id.sig'},
             ['starts-with', '$key', 'uploads/id/upload/']], ExpiresIn=300)
 

--- a/planscore/upload_fields.py
+++ b/planscore/upload_fields.py
@@ -14,7 +14,7 @@ def get_upload_fields(s3, creds, request_url, secret):
     unsigned_id, signed_id = generate_signed_id(secret)
     redirect_query = urllib.parse.urlencode(dict(id=signed_id))
     redirect_path = '{}?{}'.format(constants.API_UPLOADED_RELPATH, redirect_query)
-    acl, redirect_url = 'private', urllib.parse.urljoin(request_url, redirect_path)
+    acl, redirect_url = 'bucket-owner-full-control', urllib.parse.urljoin(request_url, redirect_path)
     
     presigned = s3.generate_presigned_post(
         constants.S3_BUCKET,


### PR DESCRIPTION
`private` was too restrictive when used between accounts.