### PR TITLE
Add logging for tile timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ transforming the politics, litigation, and coverage of redistricting.
 Install for Local Development
 ---
 
-PlanScore is a Python 3 application deployed to Amazon Web Services with S3 and
-Lambda. To make local development possible, use Docker and the local AWS
-development stack [LocalStack](https://github.com/localstack/localstack).
+PlanScore is a Python 3 application deployed to Amazon Web Services with S3,
+Lambda, and SQS. To make local development possible, use Docker and the local
+AWS development stack [LocalStack](https://github.com/localstack/localstack).
 
 1.  Clone the PlanScore git repository and prepare a
     [Python virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/#virtualenv).
@@ -44,12 +44,13 @@ development stack [LocalStack](https://github.com/localstack/localstack).
     
 7.  In a separate window, run LocalStack.
     
-        env SERVICES=s3,lambda LAMBDA_EXECUTOR=docker localstack start
+        env SERVICES=s3,lambda,sqs LAMBDA_EXECUTOR=docker localstack start
     
     Wait for the expected output.
     
         Starting local dev environment. CTRL-C to quit.
         Starting mock S3 (http port 4572)...
+        Starting mock SQS (http port 4576)...
         Starting mock Lambda service (http port 4574)...
         Ready.
     

--- a/deploy.py
+++ b/deploy.py
@@ -15,6 +15,7 @@ functions = {
     'PlanScore-AfterUpload': dict(Handler='lambda.after_upload', Timeout=300, MemorySize=512, **common),
     'PlanScore-RunDistrict': dict(Handler='lambda.run_district', Timeout=300, MemorySize=512, **common),
     'PlanScore-ScoreDistrictPlan': dict(Handler='lambda.score_plan', Timeout=300, **common),
+    'PlanScore-EmptyEqueue': dict(Handler='lambda.empty_queue', Timeout=300, **common),
     }
 
 def publish_function(lam, name, path, env, role):

--- a/deploy.py
+++ b/deploy.py
@@ -53,7 +53,8 @@ parser.add_argument('name', help='Function name')
 
 if __name__ == '__main__':
     args = parser.parse_args()
-    env = {k: os.environ[k] for k in ('PLANSCORE_SECRET', 'WEBSITE_BASE', 'AWS')
+    env = {k: os.environ[k]
+        for k in ('PLANSCORE_SECRET', 'WEBSITE_BASE', 'AWS', 'SQS_QUEUEURL')
         if k in os.environ}
     
     lam = boto3.client('lambda', region_name='us-east-1')

--- a/lambda.py
+++ b/lambda.py
@@ -3,3 +3,4 @@ from planscore.upload_fields import lambda_handler as upload_fields
 from planscore.callback import lambda_handler as callback
 from planscore.districts import lambda_handler as run_district
 from planscore.score import lambda_handler as score_plan
+from planscore.empty_queue import lambda_handler as empty_queue

--- a/planscore/constants.py
+++ b/planscore/constants.py
@@ -15,6 +15,9 @@ SECRET = os.environ.get('PLANSCORE_SECRET', 'fake')
 # S3 bucket name, which should generally be left alone.
 S3_BUCKET = os.environ.get('S3_BUCKET', 'planscore')
 
+# SQS queue URL
+SQS_QUEUEURL = os.environ.get('SQS_NAME')
+
 # Website and API URLs.
 #
 # Used to coordinate links, form actions, and redirects between Flask app
@@ -43,11 +46,12 @@ API_UPLOADED_RELPATH = 'uploaded'
 # localstack mock services. See also setup-localstack.py.
 
 S3_ENDPOINT_URL = os.environ.get('S3_ENDPOINT_URL', _local_url(4572))
+SQS_ENDPOINT_URL = os.environ.get('SQS_ENDPOINT_URL', _local_url(4561))
 LAMBDA_ENDPOINT_URL = os.environ.get('LAMBDA_ENDPOINT_URL', _local_url(4574))
 S3_URL_PATTERN = urllib.parse.urljoin(S3_ENDPOINT_URL, '/{b}/{k}')
 
-if os.environ.get('AWS', 'localstack') == 'amazonaws.com':
-    S3_ENDPOINT_URL, LAMBDA_ENDPOINT_URL = None, None
+if os.environ.get('AWS') == 'amazonaws.com':
+    S3_ENDPOINT_URL, SQS_ENDPOINT_URL, LAMBDA_ENDPOINT_URL = None, None, None
     S3_URL_PATTERN = 'https://{b}.s3.amazonaws.com/{k}'
 
 # Active version of each state model

--- a/planscore/constants.py
+++ b/planscore/constants.py
@@ -15,9 +15,6 @@ SECRET = os.environ.get('PLANSCORE_SECRET', 'fake')
 # S3 bucket name, which should generally be left alone.
 S3_BUCKET = os.environ.get('S3_BUCKET', 'planscore')
 
-# SQS queue URL
-SQS_QUEUEURL = os.environ.get('SQS_NAME')
-
 # Website and API URLs.
 #
 # Used to coordinate links, form actions, and redirects between Flask app
@@ -49,10 +46,12 @@ S3_ENDPOINT_URL = os.environ.get('S3_ENDPOINT_URL', _local_url(4572))
 SQS_ENDPOINT_URL = os.environ.get('SQS_ENDPOINT_URL', _local_url(4561))
 LAMBDA_ENDPOINT_URL = os.environ.get('LAMBDA_ENDPOINT_URL', _local_url(4574))
 S3_URL_PATTERN = urllib.parse.urljoin(S3_ENDPOINT_URL, '/{b}/{k}')
+SQS_QUEUEURL = urllib.parse.urljoin(SQS_ENDPOINT_URL, '/queue/tiles')
 
 if os.environ.get('AWS') == 'amazonaws.com':
     S3_ENDPOINT_URL, SQS_ENDPOINT_URL, LAMBDA_ENDPOINT_URL = None, None, None
     S3_URL_PATTERN = 'https://{b}.s3.amazonaws.com/{k}'
+    SQS_QUEUEURL = os.environ.get('SQS_QUEUEURL')
 
 # Active version of each state model
 

--- a/planscore/empty_queue.py
+++ b/planscore/empty_queue.py
@@ -1,0 +1,47 @@
+import boto3, io, csv, json
+from datetime import datetime
+from . import constants
+
+def main():
+    s3 = boto3.client('s3', endpoint_url=constants.S3_ENDPOINT_URL)
+    sqs = boto3.client('sqs', endpoint_url=constants.SQS_ENDPOINT_URL)
+
+    wrote_something = False
+    buffer = io.StringIO()
+    fields = ('upload', 'prefix', 'tile', 'size', 'time')
+    out = csv.DictWriter(buffer, fields, dialect='excel-tab')
+    out.writeheader()
+    
+    while True:
+        resp = sqs.receive_message(QueueUrl=constants.SQS_QUEUEURL,
+            MaxNumberOfMessages=10)
+        
+        if 'Messages' not in resp:
+            break
+        
+        for message in resp['Messages']:
+            try:
+                row = json.loads(message['Body'])
+                out.writerow({k: row.get(k) for k in out.fieldnames})
+            except:
+                print('Fail', message['ReceiptHandle'])
+            else:
+                wrote_something = True
+                print('OK', message['ReceiptHandle'])
+            finally:
+                sqs.delete_message(QueueUrl=constants.SQS_QUEUEURL,
+                    ReceiptHandle=message['ReceiptHandle'])
+    
+    if not wrote_something:
+        return
+    
+    print(buffer.getvalue())
+
+    key = 'logs/{}.txt'.format(datetime.now().strftime('%Y%m%dT%H%M%S'))
+    body = buffer.getvalue().encode('utf8')
+    s3.put_object(Bucket=constants.S3_BUCKET, Key=key, Body=body, ContentType='text/plain')
+
+def lambda_handler(event, context):
+    '''
+    '''
+    return main()

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -302,13 +302,16 @@ class TestDistricts (unittest.TestCase):
         def mock_score_precinct(partial, precinct, tile_zxy):
             partial.totals['Voters'] += precinct['Voters']
         
+        storage = unittest.mock.Mock()
+        storage.prefix = 'XX/0001'
+        
         # Just use the identity function to extend precincts
         load_tile_precincts.side_effect = lambda storage, tile: tile
         score_precinct.side_effect = mock_score_precinct
         
         for (index, (totals, precincts, tiles)) in enumerate(cases):
             partial = districts.Partial(-1, totals, None, precincts, tiles, None, None, None)
-            iterations = list(districts.consume_tiles(None, partial))
+            iterations = list(districts.consume_tiles(storage, partial))
             self.assertFalse(partial.precincts, 'Precincts should be completely emptied ({})'.format(index))
             self.assertFalse(partial.tiles, 'Tiles should be completely emptied ({})'.format(index))
             self.assertEqual(partial.totals['Voters'], 15, '({})'.format(index))
@@ -324,6 +327,9 @@ class TestDistricts (unittest.TestCase):
         def mock_score_precinct(partial, precinct, tile_zxy):
             partial.totals['Voters'] += precinct['Voters']
         
+        storage = unittest.mock.Mock()
+        storage.prefix = 'XX/0001'
+        
         # Just use the identity function to extend precincts
         load_tile_precincts.side_effect = lambda storage, tile: tile
         score_precinct.side_effect = mock_score_precinct
@@ -333,7 +339,7 @@ class TestDistricts (unittest.TestCase):
         
         upload = data.Upload('ID', None)
         partial = districts.Partial(-1, totals, None, precincts, tiles, None, upload, None)
-        call = districts.consume_tiles(None, partial)
+        call = districts.consume_tiles(storage, partial)
         self.assertEqual((partial.index, partial.totals, partial.precincts, partial.tiles, partial.upload.id),
             (-1, {'Voters': 0}, [{'Voters': 1}], [({'Voters': 2}, ), ({'Voters': 4}, {'Voters': 8})], 'ID'),
             'Should see the original lists unchanged')

--- a/planscore/tests/test_districts.py
+++ b/planscore/tests/test_districts.py
@@ -137,7 +137,9 @@ class TestDistricts (unittest.TestCase):
     @unittest.mock.patch('planscore.compactness.get_scores')
     @unittest.mock.patch('planscore.districts.post_score_results')
     @unittest.mock.patch('planscore.districts.consume_tiles')
-    def test_lambda_handler_init(self, consume_tiles, post_score_results, get_scores, boto3_client, stdout):
+    @unittest.mock.patch('planscore.util.add_sqs_logging_handler')
+    def test_lambda_handler_init(self, add_sqs_logging_handler, consume_tiles,
+        post_score_results, get_scores, boto3_client, stdout):
         ''' Lambda event data with just geometry starts the process.
         '''
         s3 = boto3_client.return_value
@@ -164,7 +166,9 @@ class TestDistricts (unittest.TestCase):
     @unittest.mock.patch('planscore.compactness.get_scores')
     @unittest.mock.patch('planscore.districts.post_score_results')
     @unittest.mock.patch('planscore.districts.consume_tiles')
-    def test_lambda_handler_timeout(self, consume_tiles, post_score_results, get_scores, boto3_client, stdout):
+    @unittest.mock.patch('planscore.util.add_sqs_logging_handler')
+    def test_lambda_handler_timeout(self, add_sqs_logging_handler, consume_tiles,
+        post_score_results, get_scores, boto3_client, stdout):
         ''' Lambda event hands off the process when no time is left.
         '''
         s3 = boto3_client.return_value
@@ -196,7 +200,9 @@ class TestDistricts (unittest.TestCase):
     @unittest.mock.patch('planscore.compactness.get_scores')
     @unittest.mock.patch('planscore.districts.post_score_results')
     @unittest.mock.patch('planscore.districts.consume_tiles')
-    def test_lambda_handler_continue(self, consume_tiles, post_score_results, get_scores, boto3_client, stdout):
+    @unittest.mock.patch('planscore.util.add_sqs_logging_handler')
+    def test_lambda_handler_continue(self, add_sqs_logging_handler, consume_tiles,
+        post_score_results, get_scores, boto3_client, stdout):
         ''' Lambda event data with existing totals continues the process.
         '''
         s3 = boto3_client.return_value
@@ -222,7 +228,9 @@ class TestDistricts (unittest.TestCase):
     @unittest.mock.patch('planscore.compactness.get_scores')
     @unittest.mock.patch('planscore.districts.post_score_results')
     @unittest.mock.patch('planscore.districts.consume_tiles')
-    def test_lambda_handler_final(self, consume_tiles, post_score_results, get_scores, boto3_client, stdout):
+    @unittest.mock.patch('planscore.util.add_sqs_logging_handler')
+    def test_lambda_handler_final(self, add_sqs_logging_handler, consume_tiles,
+        post_score_results, get_scores, boto3_client, stdout):
         ''' Lambda event for the final district does not hand off to the score function.
         '''
         s3 = boto3_client.return_value
@@ -242,7 +250,9 @@ class TestDistricts (unittest.TestCase):
     @unittest.mock.patch('boto3.client')
     @unittest.mock.patch('planscore.compactness.get_scores')
     @unittest.mock.patch('planscore.districts.consume_tiles')
-    def test_lambda_handler_overdue(self, consume_tiles, get_scores, boto3_client, stdout):
+    @unittest.mock.patch('planscore.util.add_sqs_logging_handler')
+    def test_lambda_handler_overdue(self, add_sqs_logging_handler, consume_tiles,
+        get_scores, boto3_client, stdout):
         ''' Lambda event for an overdue upload errors out.
         '''
         s3 = boto3_client.return_value

--- a/planscore/tests/test_util.py
+++ b/planscore/tests/test_util.py
@@ -1,5 +1,5 @@
 import unittest, unittest.mock, io, os, logging
-from .. import util
+from .. import util, constants
 
 class TestUtil (unittest.TestCase):
 
@@ -51,3 +51,17 @@ class TestUtil (unittest.TestCase):
         
         client.send_message.assert_called_once_with(MessageBody='{"hello": "world"}',
             QueueUrl='http://example.com/queue')
+    
+    @unittest.mock.patch('logging.getLogger')
+    @unittest.mock.patch('planscore.util.SQSLoggingHandler')
+    @unittest.mock.patch('boto3.client')
+    def test_add_sqs_logging_handler(self, boto3_client, SQSLoggingHandler, getLogger):
+        '''
+        '''
+        logger = getLogger.return_value
+        util.add_sqs_logging_handler('yo')
+        
+        SQSLoggingHandler.assert_called_once_with(boto3_client.return_value, constants.SQS_QUEUEURL)
+        logger.addHandler.assert_called_once_with(SQSLoggingHandler.return_value)
+        logger.setLevel.assert_called_once_with(logging.INFO)
+        getLogger.assert_called_once_with('yo')

--- a/planscore/util.py
+++ b/planscore/util.py
@@ -1,5 +1,6 @@
 import urllib.parse, tempfile, shutil, os, contextlib, logging
 import boto3
+from . import constants
 
 class SQSLoggingHandler(logging.Handler):
     ''' Logs to the given Amazon SQS queue; meant for timing logs.
@@ -37,3 +38,17 @@ def event_query_args(event):
     '''
     '''
     return event.get('queryStringParameters') or {}
+
+def add_sqs_logging_handler(name):
+    '''
+    '''
+    if constants.SQS_QUEUEURL is None:
+        return
+    
+    client = boto3.client('sqs', endpoint_url=constants.SQS_ENDPOINT_URL)
+    handler = SQSLoggingHandler(client, constants.SQS_QUEUEURL)
+    handler.setFormatter(logging.Formatter('%(message)s'))
+    
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)

--- a/planscore/util.py
+++ b/planscore/util.py
@@ -1,4 +1,17 @@
-import urllib.parse, tempfile, shutil, os, contextlib
+import urllib.parse, tempfile, shutil, os, contextlib, logging
+import boto3
+
+class SQSLoggingHandler(logging.Handler):
+    ''' Logs to the given Amazon SQS queue; meant for timing logs.
+    '''
+    def __init__(self, sqs_client, queue_url, *args, **kwargs):
+        super(SQSLoggingHandler, self).__init__(*args, **kwargs)
+        self.client, self.queue_url = sqs_client, queue_url
+        self.setFormatter(logging.Formatter('%(message)s'))
+        self.setLevel(logging.DEBUG)
+    
+    def emit(self, record):
+        self.client.send_message(QueueUrl=self.queue_url, MessageBody=self.format(record))
 
 @contextlib.contextmanager
 def temporary_buffer_file(filename, buffer):

--- a/setup-localstack.py
+++ b/setup-localstack.py
@@ -13,9 +13,18 @@ host_address = socket.gethostbyname(socket.gethostname())
 
 BUCKETNAME = 'planscore'
 ENDPOINT_S3 = 'http://{}:4572'.format(host_address)
+ENDPOINT_SQS = 'http://{}:4561'.format(host_address)
 ENDPOINT_LAM = 'http://{}:4574'.format(host_address)
 AWS_CREDS = dict(aws_access_key_id='nobody', aws_secret_access_key='nothing')
 CODE_PATH = arguments.code_path
+
+# SQS Queue setup
+
+print('--> Set up SQS', ENDPOINT_SQS)
+sqs = boto3.client('sqs', endpoint_url=ENDPOINT_SQS, **AWS_CREDS)
+
+print('    Create "tiles" queue')
+sqs.create_queue(QueueName='tiles')
 
 # S3 Bucket setup
 

--- a/setup-localstack.py
+++ b/setup-localstack.py
@@ -88,6 +88,7 @@ env = {
     'PLANSCORE_SECRET': 'localstack',
     'WEBSITE_BASE': 'http://127.0.0.1:5000/',
     'S3_ENDPOINT_URL': ENDPOINT_S3,
+    'SQS_ENDPOINT_URL': ENDPOINT_SQS,
     'LAMBDA_ENDPOINT_URL': ENDPOINT_LAM,
     }
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     entry_points = dict(
         console_scripts = [
             'planscore-prepare-state = planscore.prepare_state:main',
+            'planscore-empty-queue = planscore.empty_queue:main',
             ]
         ),
 )


### PR DESCRIPTION
Log units of work for individual tiles so this can be measured and optimized. Introduces new dependency on Amazon SQS, with required `SQS_QUEUEURL` environment variable for existing `PlanScore-RunDistrict` and new `PlanScore-EmptyQueue` Lambda functions.