### PR TITLE
Issue 213: State page metric tabs: Always show "more biased than X%" even if balanced

### DIFF
--- a/_statetemplate/state_template.js6
+++ b/_statetemplate/state_template.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/_statetemplate/state_template.js6
+++ b/_statetemplate/state_template.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/alabama/index.js6
+++ b/alabama/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/alabama/index.js6
+++ b/alabama/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/alaska/index.js6
+++ b/alaska/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/alaska/index.js6
+++ b/alaska/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/arizona/index.js6
+++ b/arizona/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/arizona/index.js6
+++ b/arizona/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/arkansas/index.js6
+++ b/arkansas/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/arkansas/index.js6
+++ b/arkansas/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/california/index.js6
+++ b/california/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/california/index.js6
+++ b/california/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/colorado/index.js6
+++ b/colorado/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/colorado/index.js6
+++ b/colorado/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/connecticut/index.js6
+++ b/connecticut/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/connecticut/index.js6
+++ b/connecticut/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/delaware/index.js6
+++ b/delaware/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/delaware/index.js6
+++ b/delaware/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/florida/index.js6
+++ b/florida/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/florida/index.js6
+++ b/florida/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/georgia/index.js6
+++ b/georgia/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/georgia/index.js6
+++ b/georgia/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/hawaii/index.js6
+++ b/hawaii/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/hawaii/index.js6
+++ b/hawaii/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/idaho/index.js6
+++ b/idaho/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/idaho/index.js6
+++ b/idaho/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/illinois/index.js6
+++ b/illinois/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/illinois/index.js6
+++ b/illinois/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/indiana/index.js6
+++ b/indiana/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/indiana/index.js6
+++ b/indiana/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/iowa/index.js6
+++ b/iowa/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/iowa/index.js6
+++ b/iowa/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/kansas/index.js6
+++ b/kansas/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/kansas/index.js6
+++ b/kansas/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/kentucky/index.js6
+++ b/kentucky/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/kentucky/index.js6
+++ b/kentucky/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/louisiana/index.js6
+++ b/louisiana/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/louisiana/index.js6
+++ b/louisiana/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/maine/index.js6
+++ b/maine/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/maine/index.js6
+++ b/maine/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/maryland/index.js6
+++ b/maryland/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/maryland/index.js6
+++ b/maryland/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/massachusetts/index.js6
+++ b/massachusetts/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/massachusetts/index.js6
+++ b/massachusetts/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/michigan/index.js6
+++ b/michigan/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/michigan/index.js6
+++ b/michigan/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/minnesota/index.js6
+++ b/minnesota/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/minnesota/index.js6
+++ b/minnesota/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/mississippi/index.js6
+++ b/mississippi/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/mississippi/index.js6
+++ b/mississippi/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/missouri/index.js6
+++ b/missouri/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/missouri/index.js6
+++ b/missouri/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/montana/index.js6
+++ b/montana/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/montana/index.js6
+++ b/montana/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/nebraska/index.js6
+++ b/nebraska/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/nebraska/index.js6
+++ b/nebraska/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/nevada/index.js6
+++ b/nevada/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/nevada/index.js6
+++ b/nevada/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/new_hampshire/index.js6
+++ b/new_hampshire/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/new_hampshire/index.js6
+++ b/new_hampshire/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/new_jersey/index.js6
+++ b/new_jersey/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/new_jersey/index.js6
+++ b/new_jersey/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/new_mexico/index.js6
+++ b/new_mexico/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/new_mexico/index.js6
+++ b/new_mexico/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/new_york/index.js6
+++ b/new_york/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/new_york/index.js6
+++ b/new_york/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/north_carolina/index.js6
+++ b/north_carolina/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/north_carolina/index.js6
+++ b/north_carolina/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/north_dakota/index.js6
+++ b/north_dakota/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/north_dakota/index.js6
+++ b/north_dakota/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/ohio/index.js6
+++ b/ohio/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/ohio/index.js6
+++ b/ohio/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/oklahoma/index.js6
+++ b/oklahoma/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/oklahoma/index.js6
+++ b/oklahoma/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/oregon/index.js6
+++ b/oregon/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/oregon/index.js6
+++ b/oregon/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/pennsylvania/index.js6
+++ b/pennsylvania/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/pennsylvania/index.js6
+++ b/pennsylvania/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/rhode_island/index.js6
+++ b/rhode_island/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/rhode_island/index.js6
+++ b/rhode_island/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/south_carolina/index.js6
+++ b/south_carolina/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/south_carolina/index.js6
+++ b/south_carolina/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/south_dakota/index.js6
+++ b/south_dakota/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/south_dakota/index.js6
+++ b/south_dakota/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/tennessee/index.js6
+++ b/tennessee/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/tennessee/index.js6
+++ b/tennessee/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/texas/index.js6
+++ b/texas/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/texas/index.js6
+++ b/texas/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/utah/index.js6
+++ b/utah/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/utah/index.js6
+++ b/utah/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/vermont/index.js6
+++ b/vermont/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/vermont/index.js6
+++ b/vermont/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/virginia/index.js6
+++ b/virginia/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/virginia/index.js6
+++ b/virginia/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/washington/index.js6
+++ b/washington/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/washington/index.js6
+++ b/washington/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/west_virginia/index.js6
+++ b/west_virginia/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/west_virginia/index.js6
+++ b/west_virginia/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/wisconsin/index.js6
+++ b/wisconsin/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/wisconsin/index.js6
+++ b/wisconsin/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 

--- a/wyoming/index.js6
+++ b/wyoming/index.js6
@@ -584,7 +584,8 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-    const biastext_eg    = isbiased_eg ? `This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     const biaseval_pb    = lookupBias('pb', pb_score);
@@ -595,7 +596,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-    const biastext_pb    = isbiased_pb ? `This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
     const biaseval_mm    = lookupBias('mm', mm_score);
@@ -606,7 +608,8 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-    const biastext_mm    = isbiased_mm ? `This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.` : 'No consistent skew was found in favor of either party.';
+//gda
+    const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
     // color the tab-swatches for the three metrics

--- a/wyoming/index.js6
+++ b/wyoming/index.js6
@@ -584,7 +584,6 @@ window.updateMetricsTabs = (yeardata) => {
     const isbiased_eg    = biaseval_eg.isbiased;
     const hadseats       = favor_party_eg == 'Republican' ? seats_rep : seats_dem;
     const statement_eg   = `${! isbiased_eg ? 'This metric indicates a balanced plan.' : ''} Votes for ${favor_party_eg} candidates were wasted at a rate ${(100 * Math.abs(eg_score)).toFixed(1)}% lower than votes for ${loser_party_eg} candidates.`;
-//gda
     const biastext_eg    = `${! isbiased_eg ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * eg_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_eg  = Math.round(100 * Math.abs(eg_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 
@@ -596,7 +595,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_pb    = biaseval_pb.cssclass;
     const isbiased_pb    = biaseval_pb.isbiased;
     const statement_pb   = `${! isbiased_pb ? 'This metric indicates a balanced plan.' : ''} ${favor_party_pb}s would win ${(100 * Math.abs(pb_score)).toFixed(1)}% extra seats in a hypothetical, perfectly tied election.`;
-//gda
     const biastext_pb    = `${! isbiased_pb ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * bias_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_pb  = Math.round(100 * Math.abs(pb_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
  
@@ -608,7 +606,6 @@ window.updateMetricsTabs = (yeardata) => {
     const cssclass_mm    = biaseval_mm.cssclass;
     const isbiased_mm    = biaseval_mm.isbiased;
     const statement_mm   = `${! isbiased_mm ? 'This metric indicates a balanced plan.' : ''} The median ${favor_party_mm} vote share was ${(100 * Math.abs(mm_score)).toFixed(1)}% higher than the mean ${favor_party_mm} vote share.`;
-//gda
     const biastext_mm    = `${! isbiased_mm ? 'No consistent skew was found in favor of either party.' : ''} This plan is more skewed than ${Math.round(100 * mmd_rank)}% of the enacted plans we have analyzed nationwide.`;
     const roundscore_mm  = Math.round(100 * Math.abs(mm_score));  // per issue 170 these ignore the usual balanced-threshold; we want to show even 1% but keep a balanced color
 


### PR DESCRIPTION
See issue #213

State pages, the 3 metric tabs.

If a plan is balanced, the phrasing "No consistent skew was found in favor of either party." would be displayed *in lieu of* the "This plan is more skewed than X%"

As of this PR, the "more skwwed than" phrase will be displayed even if the plan is balanced.
