### PR TITLE
Issue 217, support for alternative election schedules

### DIFF
--- a/_statetemplate/state_template.js6
+++ b/_statetemplate/state_template.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/_statetemplate/state_template.js6
+++ b/_statetemplate/state_template.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/_statetemplate/state_template.js6
+++ b/_statetemplate/state_template.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/_statetemplate/state_template.js6
+++ b/_statetemplate/state_template.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/_statetemplate/state_template.js6
+++ b/_statetemplate/state_template.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/_statetemplate/state_template.scss
+++ b/_statetemplate/state_template.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/_statetemplate/state_template.src.html
+++ b/_statetemplate/state_template.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">STATE_NAME</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/alabama/index.js6
+++ b/alabama/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/alabama/index.js6
+++ b/alabama/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/alabama/index.js6
+++ b/alabama/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/alabama/index.js6
+++ b/alabama/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/alabama/index.js6
+++ b/alabama/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/alabama/index.scss
+++ b/alabama/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/alabama/index.src.html
+++ b/alabama/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Alabama</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/alaska/index.js6
+++ b/alaska/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/alaska/index.js6
+++ b/alaska/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/alaska/index.js6
+++ b/alaska/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/alaska/index.js6
+++ b/alaska/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/alaska/index.js6
+++ b/alaska/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/alaska/index.scss
+++ b/alaska/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/alaska/index.src.html
+++ b/alaska/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Alaska</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/arizona/index.js6
+++ b/arizona/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/arizona/index.js6
+++ b/arizona/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/arizona/index.js6
+++ b/arizona/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/arizona/index.js6
+++ b/arizona/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/arizona/index.js6
+++ b/arizona/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/arizona/index.scss
+++ b/arizona/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/arizona/index.src.html
+++ b/arizona/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Arizona</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/arkansas/index.js6
+++ b/arkansas/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/arkansas/index.js6
+++ b/arkansas/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/arkansas/index.js6
+++ b/arkansas/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/arkansas/index.js6
+++ b/arkansas/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/arkansas/index.js6
+++ b/arkansas/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/arkansas/index.scss
+++ b/arkansas/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/arkansas/index.src.html
+++ b/arkansas/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Arkansas</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/california/index.js6
+++ b/california/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/california/index.js6
+++ b/california/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/california/index.js6
+++ b/california/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/california/index.js6
+++ b/california/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/california/index.js6
+++ b/california/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/california/index.scss
+++ b/california/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/california/index.src.html
+++ b/california/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">California</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/colorado/index.js6
+++ b/colorado/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/colorado/index.js6
+++ b/colorado/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/colorado/index.js6
+++ b/colorado/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/colorado/index.js6
+++ b/colorado/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/colorado/index.js6
+++ b/colorado/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/colorado/index.scss
+++ b/colorado/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/colorado/index.src.html
+++ b/colorado/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Colorado</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/connecticut/index.js6
+++ b/connecticut/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/connecticut/index.js6
+++ b/connecticut/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/connecticut/index.js6
+++ b/connecticut/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/connecticut/index.js6
+++ b/connecticut/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/connecticut/index.js6
+++ b/connecticut/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/connecticut/index.scss
+++ b/connecticut/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/connecticut/index.src.html
+++ b/connecticut/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Connecticut</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/delaware/index.js6
+++ b/delaware/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/delaware/index.js6
+++ b/delaware/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/delaware/index.js6
+++ b/delaware/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/delaware/index.js6
+++ b/delaware/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/delaware/index.js6
+++ b/delaware/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/delaware/index.scss
+++ b/delaware/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/delaware/index.src.html
+++ b/delaware/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Delaware</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/florida/index.js6
+++ b/florida/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/florida/index.js6
+++ b/florida/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/florida/index.js6
+++ b/florida/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/florida/index.js6
+++ b/florida/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/florida/index.js6
+++ b/florida/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/florida/index.scss
+++ b/florida/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/florida/index.src.html
+++ b/florida/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Florida</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/georgia/index.js6
+++ b/georgia/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/georgia/index.js6
+++ b/georgia/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/georgia/index.js6
+++ b/georgia/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/georgia/index.js6
+++ b/georgia/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/georgia/index.js6
+++ b/georgia/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/georgia/index.scss
+++ b/georgia/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/georgia/index.src.html
+++ b/georgia/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Georgia</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/hawaii/index.js6
+++ b/hawaii/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/hawaii/index.js6
+++ b/hawaii/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/hawaii/index.js6
+++ b/hawaii/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/hawaii/index.js6
+++ b/hawaii/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/hawaii/index.js6
+++ b/hawaii/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/hawaii/index.scss
+++ b/hawaii/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/hawaii/index.src.html
+++ b/hawaii/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Hawaii</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/idaho/index.js6
+++ b/idaho/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/idaho/index.js6
+++ b/idaho/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/idaho/index.js6
+++ b/idaho/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/idaho/index.js6
+++ b/idaho/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/idaho/index.js6
+++ b/idaho/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/idaho/index.scss
+++ b/idaho/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/idaho/index.src.html
+++ b/idaho/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Idaho</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/illinois/index.js6
+++ b/illinois/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/illinois/index.js6
+++ b/illinois/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/illinois/index.js6
+++ b/illinois/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/illinois/index.js6
+++ b/illinois/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/illinois/index.js6
+++ b/illinois/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/illinois/index.scss
+++ b/illinois/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/illinois/index.src.html
+++ b/illinois/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Illinois</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/index.js6
+++ b/index.js6
@@ -220,6 +220,7 @@ window.loadDataForSelectedBoundaryAndYear = (options={}) => {
         complete: function (results) {
             // issue 169, if fudgeYearIfNoData is enabled and we have no data for this year, pick another year
             // nearest year to our chosen which does have data, favoring more-recent year in event of a tie
+            // primarily used when switching district types, as not all district types have the same coverage for every year (e.g. State House 2016)
             if (options.fudgeYearIfNoData) {
                 const hasdata = results.data.filter((datarow) => { return datarow.year == CURRENT_VIEW.year; }).length;
                 if (! hasdata) {
@@ -239,6 +240,17 @@ window.loadDataForSelectedBoundaryAndYear = (options={}) => {
                     return;
                 }
             }
+
+            // issue 217: odd-numbered years
+            // our whole yearpicker concept was based on even-numbered years,
+            // but a few states have unusual cycles such as odd-numbered years, and some unusual cases e.g. KY which in 1981-1984 changed from odd-numbered to even-numbered
+            // workaround here: rewrite any odd-numbered years to add 1 (1973 becomes 1974) so we still have even numbers
+            // for this visual display having 1974 show the plan enacted in 1973 is sufficiently accurate
+            results.data = results.data.map(function (datarow) {
+                const year = parseInt(datarow.year);
+                if (year % 2 == 1) datarow.year = String(year + 1);
+                return datarow;
+            });
 
             // filter by the year (geography is implicit by which CSV was fetched)
             // and for each row assign the bias score to the state's row in the above

--- a/indiana/index.js6
+++ b/indiana/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/indiana/index.js6
+++ b/indiana/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/indiana/index.js6
+++ b/indiana/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/indiana/index.js6
+++ b/indiana/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/indiana/index.js6
+++ b/indiana/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/indiana/index.scss
+++ b/indiana/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/indiana/index.src.html
+++ b/indiana/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Indiana</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/iowa/index.js6
+++ b/iowa/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/iowa/index.js6
+++ b/iowa/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/iowa/index.js6
+++ b/iowa/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/iowa/index.js6
+++ b/iowa/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/iowa/index.js6
+++ b/iowa/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/iowa/index.scss
+++ b/iowa/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/iowa/index.src.html
+++ b/iowa/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Iowa</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/kansas/index.js6
+++ b/kansas/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/kansas/index.js6
+++ b/kansas/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/kansas/index.js6
+++ b/kansas/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/kansas/index.js6
+++ b/kansas/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/kansas/index.js6
+++ b/kansas/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/kansas/index.scss
+++ b/kansas/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/kansas/index.src.html
+++ b/kansas/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Kansas</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/kentucky/index.js6
+++ b/kentucky/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/kentucky/index.js6
+++ b/kentucky/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/kentucky/index.js6
+++ b/kentucky/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/kentucky/index.js6
+++ b/kentucky/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/kentucky/index.js6
+++ b/kentucky/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/kentucky/index.scss
+++ b/kentucky/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/kentucky/index.src.html
+++ b/kentucky/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Kentucky</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/louisiana/index.js6
+++ b/louisiana/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/louisiana/index.js6
+++ b/louisiana/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/louisiana/index.js6
+++ b/louisiana/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/louisiana/index.js6
+++ b/louisiana/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/louisiana/index.js6
+++ b/louisiana/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/louisiana/index.scss
+++ b/louisiana/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/louisiana/index.src.html
+++ b/louisiana/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Louisiana</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/maine/index.js6
+++ b/maine/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/maine/index.js6
+++ b/maine/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/maine/index.js6
+++ b/maine/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/maine/index.js6
+++ b/maine/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/maine/index.js6
+++ b/maine/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/maine/index.scss
+++ b/maine/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/maine/index.src.html
+++ b/maine/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Maine</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/maryland/index.js6
+++ b/maryland/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/maryland/index.js6
+++ b/maryland/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/maryland/index.js6
+++ b/maryland/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/maryland/index.js6
+++ b/maryland/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/maryland/index.js6
+++ b/maryland/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/maryland/index.scss
+++ b/maryland/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/maryland/index.src.html
+++ b/maryland/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Maryland</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/massachusetts/index.js6
+++ b/massachusetts/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/massachusetts/index.js6
+++ b/massachusetts/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/massachusetts/index.js6
+++ b/massachusetts/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/massachusetts/index.js6
+++ b/massachusetts/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/massachusetts/index.js6
+++ b/massachusetts/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/massachusetts/index.scss
+++ b/massachusetts/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/massachusetts/index.src.html
+++ b/massachusetts/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Massachusetts</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/michigan/index.js6
+++ b/michigan/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/michigan/index.js6
+++ b/michigan/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/michigan/index.js6
+++ b/michigan/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/michigan/index.js6
+++ b/michigan/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/michigan/index.js6
+++ b/michigan/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/michigan/index.scss
+++ b/michigan/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/michigan/index.src.html
+++ b/michigan/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Michigan</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/minnesota/index.js6
+++ b/minnesota/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/minnesota/index.js6
+++ b/minnesota/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/minnesota/index.js6
+++ b/minnesota/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/minnesota/index.js6
+++ b/minnesota/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/minnesota/index.js6
+++ b/minnesota/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/minnesota/index.scss
+++ b/minnesota/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/minnesota/index.src.html
+++ b/minnesota/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Minnesota</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/mississippi/index.js6
+++ b/mississippi/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/mississippi/index.js6
+++ b/mississippi/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/mississippi/index.js6
+++ b/mississippi/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/mississippi/index.js6
+++ b/mississippi/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/mississippi/index.js6
+++ b/mississippi/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/mississippi/index.scss
+++ b/mississippi/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/mississippi/index.src.html
+++ b/mississippi/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Mississippi</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/missouri/index.js6
+++ b/missouri/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/missouri/index.js6
+++ b/missouri/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/missouri/index.js6
+++ b/missouri/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/missouri/index.js6
+++ b/missouri/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/missouri/index.js6
+++ b/missouri/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/missouri/index.scss
+++ b/missouri/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/missouri/index.src.html
+++ b/missouri/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Missouri</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/montana/index.js6
+++ b/montana/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/montana/index.js6
+++ b/montana/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/montana/index.js6
+++ b/montana/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/montana/index.js6
+++ b/montana/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/montana/index.js6
+++ b/montana/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/montana/index.scss
+++ b/montana/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/montana/index.src.html
+++ b/montana/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Montana</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/nebraska/index.js6
+++ b/nebraska/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/nebraska/index.js6
+++ b/nebraska/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/nebraska/index.js6
+++ b/nebraska/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/nebraska/index.js6
+++ b/nebraska/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/nebraska/index.js6
+++ b/nebraska/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/nebraska/index.scss
+++ b/nebraska/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/nebraska/index.src.html
+++ b/nebraska/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Nebraska</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/nevada/index.js6
+++ b/nevada/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/nevada/index.js6
+++ b/nevada/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/nevada/index.js6
+++ b/nevada/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/nevada/index.js6
+++ b/nevada/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/nevada/index.js6
+++ b/nevada/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/nevada/index.scss
+++ b/nevada/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/nevada/index.src.html
+++ b/nevada/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Nevada</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/new_hampshire/index.js6
+++ b/new_hampshire/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/new_hampshire/index.js6
+++ b/new_hampshire/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/new_hampshire/index.js6
+++ b/new_hampshire/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/new_hampshire/index.js6
+++ b/new_hampshire/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/new_hampshire/index.js6
+++ b/new_hampshire/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/new_hampshire/index.scss
+++ b/new_hampshire/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/new_hampshire/index.src.html
+++ b/new_hampshire/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">New Hampshire</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/new_jersey/index.js6
+++ b/new_jersey/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/new_jersey/index.js6
+++ b/new_jersey/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/new_jersey/index.js6
+++ b/new_jersey/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/new_jersey/index.js6
+++ b/new_jersey/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/new_jersey/index.js6
+++ b/new_jersey/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/new_jersey/index.scss
+++ b/new_jersey/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/new_jersey/index.src.html
+++ b/new_jersey/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">New Jersey</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/new_mexico/index.js6
+++ b/new_mexico/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/new_mexico/index.js6
+++ b/new_mexico/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/new_mexico/index.js6
+++ b/new_mexico/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/new_mexico/index.js6
+++ b/new_mexico/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/new_mexico/index.js6
+++ b/new_mexico/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/new_mexico/index.scss
+++ b/new_mexico/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/new_mexico/index.src.html
+++ b/new_mexico/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">New Mexico</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/new_york/index.js6
+++ b/new_york/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/new_york/index.js6
+++ b/new_york/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/new_york/index.js6
+++ b/new_york/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/new_york/index.js6
+++ b/new_york/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/new_york/index.js6
+++ b/new_york/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/new_york/index.scss
+++ b/new_york/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/new_york/index.src.html
+++ b/new_york/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">New York</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/north_carolina/index.js6
+++ b/north_carolina/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/north_carolina/index.js6
+++ b/north_carolina/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/north_carolina/index.js6
+++ b/north_carolina/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/north_carolina/index.js6
+++ b/north_carolina/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/north_carolina/index.js6
+++ b/north_carolina/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/north_carolina/index.scss
+++ b/north_carolina/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/north_carolina/index.src.html
+++ b/north_carolina/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">North Carolina</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/north_dakota/index.js6
+++ b/north_dakota/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/north_dakota/index.js6
+++ b/north_dakota/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/north_dakota/index.js6
+++ b/north_dakota/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/north_dakota/index.js6
+++ b/north_dakota/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/north_dakota/index.js6
+++ b/north_dakota/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/north_dakota/index.scss
+++ b/north_dakota/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/north_dakota/index.src.html
+++ b/north_dakota/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">North Dakota</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/ohio/index.js6
+++ b/ohio/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/ohio/index.js6
+++ b/ohio/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/ohio/index.js6
+++ b/ohio/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/ohio/index.js6
+++ b/ohio/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/ohio/index.js6
+++ b/ohio/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/ohio/index.scss
+++ b/ohio/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/ohio/index.src.html
+++ b/ohio/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Ohio</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/oklahoma/index.js6
+++ b/oklahoma/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/oklahoma/index.js6
+++ b/oklahoma/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/oklahoma/index.js6
+++ b/oklahoma/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/oklahoma/index.js6
+++ b/oklahoma/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/oklahoma/index.js6
+++ b/oklahoma/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/oklahoma/index.scss
+++ b/oklahoma/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/oklahoma/index.src.html
+++ b/oklahoma/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Oklahoma</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/oregon/index.js6
+++ b/oregon/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/oregon/index.js6
+++ b/oregon/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/oregon/index.js6
+++ b/oregon/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/oregon/index.js6
+++ b/oregon/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/oregon/index.js6
+++ b/oregon/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/oregon/index.scss
+++ b/oregon/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/oregon/index.src.html
+++ b/oregon/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Oregon</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/pennsylvania/index.js6
+++ b/pennsylvania/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/pennsylvania/index.js6
+++ b/pennsylvania/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/pennsylvania/index.js6
+++ b/pennsylvania/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/pennsylvania/index.js6
+++ b/pennsylvania/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/pennsylvania/index.js6
+++ b/pennsylvania/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/pennsylvania/index.scss
+++ b/pennsylvania/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/pennsylvania/index.src.html
+++ b/pennsylvania/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Pennsylvania</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/rhode_island/index.js6
+++ b/rhode_island/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/rhode_island/index.js6
+++ b/rhode_island/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/rhode_island/index.js6
+++ b/rhode_island/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/rhode_island/index.js6
+++ b/rhode_island/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/rhode_island/index.js6
+++ b/rhode_island/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/rhode_island/index.scss
+++ b/rhode_island/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/rhode_island/index.src.html
+++ b/rhode_island/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Rhode Island</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/south_carolina/index.js6
+++ b/south_carolina/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/south_carolina/index.js6
+++ b/south_carolina/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/south_carolina/index.js6
+++ b/south_carolina/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/south_carolina/index.js6
+++ b/south_carolina/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/south_carolina/index.js6
+++ b/south_carolina/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/south_carolina/index.scss
+++ b/south_carolina/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/south_carolina/index.src.html
+++ b/south_carolina/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">South Carolina</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/south_dakota/index.js6
+++ b/south_dakota/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/south_dakota/index.js6
+++ b/south_dakota/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/south_dakota/index.js6
+++ b/south_dakota/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/south_dakota/index.js6
+++ b/south_dakota/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/south_dakota/index.js6
+++ b/south_dakota/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/south_dakota/index.scss
+++ b/south_dakota/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/south_dakota/index.src.html
+++ b/south_dakota/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">South Dakota</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/tennessee/index.js6
+++ b/tennessee/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/tennessee/index.js6
+++ b/tennessee/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/tennessee/index.js6
+++ b/tennessee/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/tennessee/index.js6
+++ b/tennessee/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/tennessee/index.js6
+++ b/tennessee/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/tennessee/index.scss
+++ b/tennessee/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/tennessee/index.src.html
+++ b/tennessee/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Tennessee</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/texas/index.js6
+++ b/texas/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/texas/index.js6
+++ b/texas/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/texas/index.js6
+++ b/texas/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/texas/index.js6
+++ b/texas/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/texas/index.js6
+++ b/texas/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/texas/index.scss
+++ b/texas/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/texas/index.src.html
+++ b/texas/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Texas</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/utah/index.js6
+++ b/utah/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/utah/index.js6
+++ b/utah/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/utah/index.js6
+++ b/utah/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/utah/index.js6
+++ b/utah/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/utah/index.js6
+++ b/utah/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/utah/index.scss
+++ b/utah/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/utah/index.src.html
+++ b/utah/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Utah</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/vermont/index.js6
+++ b/vermont/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/vermont/index.js6
+++ b/vermont/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/vermont/index.js6
+++ b/vermont/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/vermont/index.js6
+++ b/vermont/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/vermont/index.js6
+++ b/vermont/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/vermont/index.scss
+++ b/vermont/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/vermont/index.src.html
+++ b/vermont/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Vermont</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/virginia/index.js6
+++ b/virginia/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/virginia/index.js6
+++ b/virginia/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/virginia/index.js6
+++ b/virginia/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/virginia/index.js6
+++ b/virginia/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/virginia/index.js6
+++ b/virginia/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/virginia/index.scss
+++ b/virginia/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/virginia/index.src.html
+++ b/virginia/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Virginia</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/washington/index.js6
+++ b/washington/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/washington/index.js6
+++ b/washington/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/washington/index.js6
+++ b/washington/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/washington/index.js6
+++ b/washington/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/washington/index.js6
+++ b/washington/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/washington/index.scss
+++ b/washington/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/washington/index.src.html
+++ b/washington/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Washington</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/west_virginia/index.js6
+++ b/west_virginia/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/west_virginia/index.js6
+++ b/west_virginia/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/west_virginia/index.js6
+++ b/west_virginia/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/west_virginia/index.js6
+++ b/west_virginia/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/west_virginia/index.js6
+++ b/west_virginia/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/west_virginia/index.scss
+++ b/west_virginia/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/west_virginia/index.src.html
+++ b/west_virginia/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">West Virginia</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/wisconsin/index.js6
+++ b/wisconsin/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/wisconsin/index.js6
+++ b/wisconsin/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/wisconsin/index.js6
+++ b/wisconsin/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/wisconsin/index.js6
+++ b/wisconsin/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/wisconsin/index.js6
+++ b/wisconsin/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/wisconsin/index.scss
+++ b/wisconsin/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/wisconsin/index.src.html
+++ b/wisconsin/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Wisconsin</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>

--- a/wyoming/index.js6
+++ b/wyoming/index.js6
@@ -194,7 +194,6 @@ window.initYearPickers = () => {
     // note too that we still support showing Plan data or Election-year data
     // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
 
-//GDA
     // mobile yearpicker
     const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
     const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
@@ -886,6 +885,51 @@ window.redrawYearPickers = (csvdata) => {
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
+    }
+
+    // desktop picker
+    // lists years on the right, and draws plan-start circles on the left
+    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    {
+        // a straight list: all available years
+        // a lookup dict: year => plan (to tag a each year's link with its plan for display)
+        // a lookup dict: for each plan, its first year (to add the plan-start dots)
+        // a lookup dict: year => EG bias ratings (used for plan-start dots)
+        const available_years = [];
+        const yearplans = {};
+        const planfirstyears = {};
+        const yearbiasinfo = {};
+        csvdata.forEach((row) => {
+            yearplans[row.year] = row.plan;
+            planfirstyears[row.plan] = row.plan_minyear;
+            yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
+        });
+        available_years.sort().reverse();  // reverses in-place but also returns it
+
+        // purge the existing links (and re-add the titles)
+        // then draw new ones one row at a time
+        // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
+        const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
+        const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
+
+        available_years.forEach((year) => {
+            const plan          = yearplans[year];
+            const planfirstyear = planfirstyears[plan];
+            const biasinfo      = yearbiasinfo[year];
+
+            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
+            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+
+            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+            if (year == planfirstyear) {
+                $planlink.removeClass('plan-continue').addClass('plan-begin');
+                $planlink.find('span').css({ 'background-color': biasinfo.color });
+            }
+
+            // if this is the currently-selected year, tag it as such
+//gda
+        });
     }
 };
 

--- a/wyoming/index.js6
+++ b/wyoming/index.js6
@@ -908,12 +908,18 @@ window.redrawYearPickers = (csvdata) => {
         available_years.sort();
 
         // pad the years list with null-years, where we find a gap larger than 2 years
+        // this allows the timeline to be stretched with empty rows, so we show gaps in coverage
+        // not all states have 2-year cycles for all district types, so we hardcode these hacks to handle that chaos
+        let yearsbetweencycles = 2;
+        if (SELECTED_STATE == 'Alabama' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+        if (SELECTED_STATE == 'Mississippi' && CURRENT_VIEW.boundtype == 'statehouse') yearsbetweencycles = 4;
+
         const nullpadded_years = [];
         for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
             var thisyear = available_years[i];
             var nextyear = available_years[i+1];
 
-            for (let y=thisyear; y<nextyear; y+=2) {
+            for (let y=thisyear; y<nextyear; y+=yearsbetweencycles) {
                 nullpadded_years.push(y);
             }
         }
@@ -955,13 +961,16 @@ window.redrawYearPickers = (csvdata) => {
                 }
             }
             else {
-                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                // the null years links, don't really do nothing as discussed
+                // they must be tagged with data-plan so as to be highlighted along with other plan years
+                // and need a data-year (of a real year with data) so they can be clicked to show that year's data
+                // note: if we ever reinstate showing Election info, this fudging to show the year of the nearest plan is likely to backfire, and may need to be removed
                 let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
                 latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
                 const priorplan = yearplans[latestplanyearbeforethis];
 
-                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
-                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+                const $planlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${priorplan}" data-year="${latestplanyearbeforethis}"></a>`).appendTo($yearsdiv);
 
                 // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
                 if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {

--- a/wyoming/index.js6
+++ b/wyoming/index.js6
@@ -5,6 +5,7 @@ require('./index.src.html');
 
 // shared constants between pages: the list of years, the red-blue color gradient, ...
 import { PLAN_YEARS } from "./../_common/constants";
+import { PLAN_YEARS_PER_STATE } from "./../_common/constants";
 import { STATE_NAME_TO_CODE } from "./../_common/constants";
 import { CONUS_BOUNDS } from "./../_common/constants";
 import { STATE_BOUNDING_BOXES } from "./../_common/constants";
@@ -182,69 +183,59 @@ window.initMap = () => {
 };
 
 window.initYearPickers = () => {
-    // mobile
-    // two separate UIs for cycling through prev/next election year or district plan
-    // only one is visible and that's based on whether our URL (or defaults) indicate that we want to see a year/plan
-    // see initLoadStartingConditions() for that startup logic to show only one
-    // see selectElectionOrPlan() which does the real work when prev/next are performed
-    const $plan_picker = $('#yearpicker-small > div[data-picker="plan"]');
-    const $year_picker = $('#yearpicker-small > div[data-picker="election"]');
-    const $year_listing = $year_picker.find('div.readout');
-    const $plan_listing = $plan_picker.find('div.readout');
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
 
-    PLAN_YEARS.forEach((year) => {
-        $(`<span data-year="${year}">${year} Election</span>`).appendTo($year_listing).hide();
-    });
+    // this basically just sets the delegated event handlers, when the pickers' beads/arrows are clicked
+    // per issue 217, most of the work is in redrawYearPickers()
+    // the years offered are once again based on the years in the CSV data for the selected districttype-and-state
+    // since it turns out that not all states have the same years, or may not have the same years between the different district types
 
-    $year_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $year_listing.find('span:visible').next('span');
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) but likely to come back
+
+//GDA
+    // mobile yearpicker
+    const $planpicker_mobile  = $('#yearpicker-small > div[data-picker="plan"]');
+    const $yearpicker_mobile  = $('#yearpicker-small > div[data-picker="election"]');
+    const $yearlisting_mobile = $yearpicker_mobile.find('div.readout');
+    const $planlisting_mobile = $planpicker_mobile.find('div.readout');
+
+    $yearpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-    $year_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $year_listing.find('span:visible').prev('span');
+    $yearpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $yearlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         if (! year) return;  // don't allow clicking past the first/last
         selectElectionOrPlan(year, 'election');
     });
-
-    // there won't be any plans listed here at startup; see redrawYearPicker() since the list of plans depends on district type
-    $plan_picker.on('click', 'div.nextprev.right', function () {
-        const $targetbutton = $plan_listing.find('span:visible').next('span');
+    $planpicker_mobile.on('click', 'div.nextprev.right', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').next('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
-    $plan_picker.on('click', 'div.nextprev.left', function () {
-        const $targetbutton = $plan_listing.find('span:visible').prev('span');
+    $planpicker_mobile.on('click', 'div.nextprev.left', function () {
+        const $targetbutton = $planlisting_mobile.find('span:visible').prev('span');
         const year = $targetbutton.attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
 
-    // desktop
-    // the list of "year beads" running down the side, which is two columns for election years (right) and district plans (left)
-    // see also redrawYearPicker() which assigns the data-plan="" attribute to plans, and shows/hides election years
-    // both bases on the actual data present
-    const $picker_big   = $('#yearpicker-big');
-    const $plansdiv     = $('<div class="plans col-xs-5"></div>').appendTo($picker_big);
-    const $electionsdiv = $('<div class="elections col-xs-7"></div>').appendTo($picker_big);
-    
-    $('<span>Election<br>Years</span>').appendTo($electionsdiv);
-    $('<span>Enacted<br>Plans</span>').appendTo($plansdiv);
+    // desktop yearpicker
+    const $planpicker_desktop  = $('#yearpicker-big');
+    const $planlisting_desktop = $planpicker_desktop.find('div.plans');
+    const $yearlisting_desktop = $planpicker_desktop.find('div.elections');
 
-    PLAN_YEARS.slice().reverse().forEach((year) => {
-        $(`<a data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($electionsdiv);
-        $(`<a data-year="${year}" title="Show details for this districting plan"><span></span></a>`).appendTo($plansdiv);  // will be tagged with data-plan attribute when we have data
-    });
-
-    $electionsdiv.on('click', 'a', function () {
+    $yearlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
-        // issue 94: for the time being, years also go to Plans not election-year details
+        // issue 94: for the time being, years also go to Plans and not election-year details
         //selectElectionOrPlan(year, 'election');
         selectElectionOrPlan(year, 'plan');
     });
-
-    $plansdiv.on('click', 'a', function () {
+    $planlisting_desktop.on('click', 'a', function () {
         const year = $(this).attr('data-year');
         selectElectionOrPlan(year, 'plan');
     });
@@ -461,7 +452,7 @@ window.updateStatsFromCsvContent = (allcsvdata) => {
 
     // okay so we have SOME data for this state + district type
     // redraw the large yearpicker, indicating years in which a new plan was implemented
-    redrawYearPicker(allcsvdata);
+    redrawYearPickers(allcsvdata);
 
     // final check: do we have data for this district for the selected year?
     // if not, fill in the closest year for which we DO have data
@@ -819,136 +810,78 @@ window.updateWastedVotesChart = (yeardata) => {
     });
 };
 
-window.redrawYearPicker = (csvdata) => {
-    // THE BIG/DESKTOP YEARPICKER
-    // the big yearpicker has a button to select the given election year
-    // but also the left-most dot-and-dash thing indicating when a new plan was enacted
-    // while the years are a universal constant, the plan-enactment years depends on what district type we're discussing
-    // so must be redrawn here after data are had
-    // ALSO needs to handle missing data, hiding missing years but still drawing nice timelines for the years we do have (Alabama statehouse, issue 167)
+window.redrawYearPickers = (csvdata) => {
+    // see initYearPickers() for the delegated event handlers and further explanation
+    // per issue 217, the mobile & desktop yearpickers must be redrawn based on the years represented in the CSV
+    // for the given district type & state, since it turns out election years aren't consistent between states, nor between a state's district levels
+    // e.g. KY statehouse, ushouse, and statesenate are not the same, and are all a mix of even and odd years
+
+    // there are two separate UIs: the mobile one with "< year >" and a prev/next behavior
+    // and the desktop one forming a set of beads down the side (with colors indicating EG bias that year)
+
+    // note too that we still support showing Plan data or Election-year data
+    // even though the display of Election-level data is presently disabled (issue 94) until they want it back again
+
+    // mobile picker - election
+    // disabled per issue 94 but likely to come back, so we have to keep it working even though nobody knows it exists
+    // empty the links and draw new ones
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-        // a lookup dict: year => plan
-        // a lookup dict: for each plan, its first year
-        // a lookup dict: year => EG bias ratings
-        const yearplans = {};
-        const planfirstyears = {};
-        const yearbiases = {};
+        // make a list of years found in the data
+        const available_years = [];
         csvdata.forEach((row) => {
-            yearplans[row.year] = {
-                plan: row.plan,
-                bias: row.eg_adj_avg,
-            };
-
-            planfirstyears[row.plan] = row.plan_minyear;
-
-            yearbiases[row.year] = lookupBias('eg', row.eg_adj_avg);
+            available_years.push(parseInt(row.year));
         });
+        available_years.sort();
 
-        // the A links on the plan side & year side
-        const $planslinks = $('#yearpicker-big div.plans').find('a');
-        const $yearslinks = $('#yearpicker-big div.elections').find('a');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="election"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        // go through the year + plan links
-        // hide any which have no data
-        // tag the plan links with their plan
-        $planslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
-
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
+        const $readout = $yearpicker.find('div.readout').empty();
+        available_years.forEach((year) => {
+            const $thislink = $(`<span data-year="${year}">${year} Election</span>`).appendTo($readout).hide();
         });
-        $yearslinks.each(function () {
-            const $thislink = $(this);
-            const year      = $thislink.attr('data-year');
-            const planinfo  = yearplans[year];
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-            if (! planinfo) {
-                $thislink.attr('data-plan', '').hide();
-            }
-            else {
-                $thislink.attr('data-plan', planinfo.plan).show();
-            }
-        });
-
-        // now that we have only visible links tagged with plans
-        // assign the row with the plan-firstyear as a circle (colored by EG bias that year), and leave others as a dash
-        // based on the planfirstyears lookup created earlier
-        const default_color = '#4d599e'; // see state_template.scss and $dark-purple-color
-        $planslinks.removeClass('plan-begin').addClass('plan-continue').prop('title', 'Show details for this districting plan').find('span').css({ 'background-color': default_color });
-
-        Object.entries(planfirstyears).forEach(([plan, firstyear]) => {
-            const $thislink = $planslinks.filter(`[data-plan="${plan}"]`).last();  // last link = first year
-            const $circle   = $thislink.find('span');
-            const year      = $thislink.attr('data-year');
-            const biasinfo  = yearbiases[year];
-
-            $thislink.removeClass('plan-continue').addClass('plan-begin');
-            $circle.css({ 'background-color': biasinfo.color });
-        });
-
-        // final touch: if we are showing a Plan, then highlight the Plan clickers accordingly
-        if (CURRENT_VIEW.planorelection == 'plan') {
-            const $plinks = $('#yearpicker-big div.plans a').removeClass('active');
-            const plan = $plinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).first().attr('data-plan');
-            $plinks.filter(`[data-plan="${plan}"]`).addClass('active');
-        }
-    }
-
-    // THE SMALL/MOBILE YEARPICKER
-    // update the election year readout, showing the selected year
-    // as well as the next/prev buttons if we are now st the first/last
-    {
-        // show this year's readout
-        const $picker    = $('#yearpicker-small > div[data-picker="election"]');
-        const $yearlinks = $picker.find('> div.readout > span').hide();
-        const $thislink  = $yearlinks.filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        // detect first year and disable prev; detect last year and disable next
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');
         else                              $nextbutton.removeClass('disabled');
     }
 
-    // now the plan picker: a list of plans, and a data-year= of their starting year
+    // mobile picker - plan
+    // get the list of plans and their active years
+    // empty the links and draw new ones for the existing plans
+    // show the current year (hiding years not the current one)
+    // show/hide the prev/next links if this is the first/last year
     {
-
+        // make a list of plans found in the data
         const plans_known = {};
         csvdata.forEach((row) => {
             if (! plans_known[row.plan]) {
                 plans_known[row.plan] = { plan: row.plan, minyear: row.plan_minyear, maxyear: row.plan_maxyear };
             }
         });
-
         const plans_listing = Object.values(plans_known);
         plans_listing.sort((p,q) => { return p.minyear < q.minyear ? -1 : 1; });
 
-        const $picker = $('#yearpicker-small > div[data-picker="plan"]');
+        // update the UI: empty the current set of links, draw new ones in a hidden state, show this year's plan
+        const $yearpicker  = $('#yearpicker-small > div[data-picker="plan"]');
+        const $prevbutton  = $yearpicker.find('div.nextprev.left');
+        const $nextbutton  = $yearpicker.find('div.nextprev.right');
 
-        const $readout = $picker.find('> div.readout').empty();
+        const $readout = $yearpicker.find('div.readout').empty();
         plans_listing.forEach((planinfo) => {
             const text = planinfo.minyear == planinfo.maxyear ? `${planinfo.minyear} Plan` : `${planinfo.minyear}-${planinfo.maxyear} Plan`;
-            $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
+            const $thislink = $(`<span data-plan="${planinfo.plan}" data-year="${planinfo.minyear}" data-minyear="${planinfo.minyear}" data-maxyear="${planinfo.maxyear}">${text}</span>`).appendTo($readout).hide();
         });
+        const $thislink = $readout.find('> span').filter(`[data-year="${CURRENT_VIEW.year}"]`).show();
 
-        // show the selected year  (not easy: we have to find a range of minyear-maxyear, may not be an exact year that is offered)
-        // detect first year and disable prev; detect last year and disable next
-        const $prevbutton = $picker.find('div.nextprev.left');
-        const $nextbutton = $picker.find('div.nextprev.right');
-
-        const $thislink = $readout.find('span').filter(function () {
-            const $this = $(this);
-            return $this.attr('data-minyear') <= CURRENT_VIEW.year && $this.attr('data-maxyear') >= CURRENT_VIEW.year;
-        }).show();
-
+        // update the UI: disable the next/prev links if this is the last/first year
         if ($thislink.is(':first-child')) $prevbutton.addClass('disabled');
         else                              $prevbutton.removeClass('disabled');
         if ($thislink.is(':last-child'))  $nextbutton.addClass('disabled');

--- a/wyoming/index.js6
+++ b/wyoming/index.js6
@@ -907,6 +907,10 @@ window.redrawYearPickers = (csvdata) => {
         });
         available_years.sort().reverse();  // reverses in-place but also returns it
 
+        // for the year we are currently showing, what plan would be active?
+        // we'll use this to highlight the currently-active plan, once we have the UI laid out
+        const currentplan = yearplans[CURRENT_VIEW.year];
+
         // purge the existing links (and re-add the titles)
         // then draw new ones one row at a time
         // a row is an illusion: there is a plan-begin/plan-continue indicator on the left, and the year on the right
@@ -927,8 +931,10 @@ window.redrawYearPickers = (csvdata) => {
                 $planlink.find('span').css({ 'background-color': biasinfo.color });
             }
 
-            // if this is the currently-selected year, tag it as such
-//gda
+            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                $planlink.addClass('active');
+            }
         });
     }
 };

--- a/wyoming/index.js6
+++ b/wyoming/index.js6
@@ -889,7 +889,7 @@ window.redrawYearPickers = (csvdata) => {
 
     // desktop picker
     // lists years on the right, and draws plan-start circles on the left
-    // GDA per issue 167, try to "smooth out" "lumpy" distributions from missing years e.g. Alabama statehouse
+    // try to smooth out "lumpy" distributions by adding null years where we find larger gaps (issue 217)
     {
         // a straight list: all available years
         // a lookup dict: year => plan (to tag a each year's link with its plan for display)
@@ -905,7 +905,22 @@ window.redrawYearPickers = (csvdata) => {
             yearbiasinfo[row.year] = lookupBias('eg', row.eg_adj_avg);
             available_years.push(parseInt(row.year));
         });
-        available_years.sort().reverse();  // reverses in-place but also returns it
+        available_years.sort();
+
+        // pad the years list with null-years, where we find a gap larger than 2 years
+        const nullpadded_years = [];
+        for (var i=0, l=available_years.length; i+1<l; i++) {  // all except the last
+            var thisyear = available_years[i];
+            var nextyear = available_years[i+1];
+
+            for (let y=thisyear; y<nextyear; y+=2) {
+                nullpadded_years.push(y);
+            }
+        }
+        nullpadded_years.sort();
+
+        // reverse the years list: most recent at the top
+        nullpadded_years.reverse();
 
         // for the year we are currently showing, what plan would be active?
         // we'll use this to highlight the currently-active plan, once we have the UI laid out
@@ -917,24 +932,42 @@ window.redrawYearPickers = (csvdata) => {
         const $plansdiv = $('#yearpicker-big div.plans').empty().append('<span>Enacted<br>Plans</span>');
         const $yearsdiv = $('#yearpicker-big div.elections').empty().append('<span>Election<br>Years</span>');
 
-        available_years.forEach((year) => {
+        nullpadded_years.forEach((year) => {
             const plan          = yearplans[year];
             const planfirstyear = planfirstyears[plan];
             const biasinfo      = yearbiasinfo[year];
 
-            const $yearlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
-            const $planlink = $(`<a data-year="${year}" data-plan="${plan.plan}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+            // if this is a null year (no plan), it's really just a spacer with a plan-continue marker: no year, no click behaviors, etc.
+            // if it has a plan, it gets the year readout and all
+            if (plan) {
+                const $planlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for this districting plan"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a data-plan="${plan}" data-year="${year}" title="Show details for the ${year} election year"><span></span> ${year}</a>`).appendTo($yearsdiv);
 
-            // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
-            if (year == planfirstyear) {
-                $planlink.removeClass('plan-continue').addClass('plan-begin');
-                $planlink.find('span').css({ 'background-color': biasinfo.color });
-            }
+                // if this year is the starting year of a plan, change it from a continue-line to a start-circle with a color indicating its bias
+                if (year == planfirstyear) {
+                    $planlink.removeClass('plan-continue').addClass('plan-begin');
+                    $planlink.find('span').css({ 'background-color': biasinfo.color });
+                }
 
-            // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
-            if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
-                $planlink.addClass('active');
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && plan == currentplan) {
+                    $planlink.addClass('active');
+                }
             }
+            else {
+                // figure out what plan would have been in effect at this time, cuz we still need to highlight this "do nothing" row even though it does nothing
+                let latestplanyearbeforethis = available_years.filter((fyear) => { return fyear < year; });
+                latestplanyearbeforethis = latestplanyearbeforethis[latestplanyearbeforethis.length - 1];
+                const priorplan = yearplans[latestplanyearbeforethis];
+
+                const $planlink = $(`<a data-plan="${priorplan}"><span></span></a>`).addClass('plan-continue').appendTo($plansdiv);
+                const $yearlink = $(`<a></a>`).appendTo($yearsdiv);
+
+                // if we are currently showing Plans (as opposed to elections) and this year's plan is that, then additional highlighting
+                if (CURRENT_VIEW.planorelection == 'plan' && priorplan == currentplan) {
+                    $planlink.addClass('active');
+                }
+            }   
         });
     }
 };

--- a/wyoming/index.scss
+++ b/wyoming/index.scss
@@ -128,7 +128,7 @@ p.wehavedata {
             width: 1px;
             margin-right: 22px;
             border: 0.05em solid #4d599e;
-            background-color: #fff;
+            background-color: $dark-purple-color;
         }
 
         a.plan-begin.active span {

--- a/wyoming/index.src.html
+++ b/wyoming/index.src.html
@@ -44,6 +44,7 @@
                 <h1 class="state_name">Wyoming</h1>
 
                 <span data-hasdata-atall="true">
+                    <!-- mobile yearpicker -->
                     <div class="visible-xs-block" id="yearpicker-small">
                         <div data-picker="plan" class="row">
                             <div class="col-xs-6 left nextprev" title="Previous districting plan"><i class="glyphicon glyphicon-chevron-left"></i></div>
@@ -57,10 +58,14 @@
                         </div>
                     </div>
 
-                    <!-- below yearpicker on mobile, above yearpicker on desktop -->
+                    <!-- this note comes below the yearpicker on mobile, and above the yearpicker on desktop -->
                     <p class="wehavedata">We have <a href="https://planscore.org/about/historical-data/">data about <span data-metric="plancount" class="bold">0</span> plans, covering <span data-metric="electioncount" class="bold">0</span> elections</a>.</p>
 
-                    <div class="hidden-xs row" id="yearpicker-big"></div>
+                    <!-- desktop yearpicker -->
+                    <div class="hidden-xs row" id="yearpicker-big">
+                        <div class="plans col-xs-5"></div>
+                        <div class="elections col-xs-7"></div>
+                    </div>
 
                     <div class="gray hidden-xs" style="clear: both;">
                         <p>New Plans</p>


### PR DESCRIPTION
A whole mess of rewriting to support #217 -- the newly discovered fact that not all states-and-district types run on 2-year election cycles on even-numbered years.
* MS statehouse and AL statehouse run on 4-year cycles, even numbered
* VA statehouse runs on 2-year cycles, odd-numbered
* KY statehouse runs on 2-year cycles, though was odd-numbered from 1973-1981, then had a 3-year gap as they switched over to even-numbered years starting in 1984

Specific changes here:
* Front page map: Odd-numbered years get +1 added to them so they fit onto the established even-numbered timeline. For display purposes and not detailed-stats work, this communicates effectively without being misleading. (the 1973 plan was still in effect in 1974)
* State detail yearpickers are completely rewritten
  * Actual years in the data are presented
  * Gaps in chronology are filled with empty rows, and clicks on them pick the plan that was previously known and presumed still in effect
