### PR TITLE
Presign uploads with IAM upload-only user

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -54,7 +54,8 @@ parser.add_argument('name', help='Function name')
 if __name__ == '__main__':
     args = parser.parse_args()
     env = {k: os.environ[k]
-        for k in ('PLANSCORE_SECRET', 'WEBSITE_BASE', 'AWS', 'SQS_QUEUEURL')
+        for k in ('PLANSCORE_SECRET', 'WEBSITE_BASE', 'AWS', 'SQS_QUEUEURL',
+            'User_AWS_ACCESS_KEY_ID', 'User_AWS_SECRET_ACCESS_KEY', 'User_AWS_SESSION_TOKEN')
         if k in os.environ}
     
     lam = boto3.client('lambda', region_name='us-east-1')

--- a/deploy.py
+++ b/deploy.py
@@ -55,7 +55,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     env = {k: os.environ[k]
         for k in ('PLANSCORE_SECRET', 'WEBSITE_BASE', 'AWS', 'SQS_QUEUEURL',
-            'User_AWS_ACCESS_KEY_ID', 'User_AWS_SECRET_ACCESS_KEY', 'User_AWS_SESSION_TOKEN')
+            'Upload_AWS_ACCESS_KEY_ID', 'Upload_AWS_SECRET_ACCESS_KEY', 'Upload_AWS_SESSION_TOKEN')
         if k in os.environ}
     
     lam = boto3.client('lambda', region_name='us-east-1')

--- a/planscore/tests/test_upload_fields.py
+++ b/planscore/tests/test_upload_fields.py
@@ -45,8 +45,8 @@ class TestUploadFields (unittest.TestCase):
             self.assertEqual(creds1.secret_key, 'role-secret')
             self.assertIsNone(creds1.token)
 
-        os.environ['User_AWS_ACCESS_KEY_ID'] = 'user-key'
-        os.environ['User_AWS_SECRET_ACCESS_KEY'] = 'user-secret'
+        os.environ['Upload_AWS_ACCESS_KEY_ID'] = 'user-key'
+        os.environ['Upload_AWS_SECRET_ACCESS_KEY'] = 'user-secret'
     
         with upload_fields.iam_user_env(os.environ):
             creds2 = boto3.session.Session().get_credentials()
@@ -55,9 +55,9 @@ class TestUploadFields (unittest.TestCase):
             self.assertIsNone(creds2.token)
 
         os.environ['AWS_SESSION_TOKEN'] = 'role-token'
-        os.environ['User_AWS_ACCESS_KEY_ID'] = 'user-key'
-        os.environ['User_AWS_SECRET_ACCESS_KEY'] = 'user-secret'
-        os.environ['User_AWS_SESSION_TOKEN'] = 'user-token'
+        os.environ['Upload_AWS_ACCESS_KEY_ID'] = 'user-key'
+        os.environ['Upload_AWS_SECRET_ACCESS_KEY'] = 'user-secret'
+        os.environ['Upload_AWS_SESSION_TOKEN'] = 'user-token'
     
         with upload_fields.iam_user_env(os.environ):
             creds3 = boto3.session.Session().get_credentials()

--- a/planscore/tests/test_upload_fields.py
+++ b/planscore/tests/test_upload_fields.py
@@ -36,6 +36,12 @@ class TestUploadFields (unittest.TestCase):
         self.assertEqual(get_upload_fields.mock_calls[0][1][2:], ('http://example.com', 'fake-secret'))
     
     def test_iam_user_env(self):
+        if 'Upload_AWS_ACCESS_KEY_ID' in os.environ:
+            del os.environ['Upload_AWS_ACCESS_KEY_ID']
+    
+        if 'Upload_AWS_SECRET_ACCESS_KEY' in os.environ:
+            del os.environ['Upload_AWS_SECRET_ACCESS_KEY']
+    
         os.environ['AWS_ACCESS_KEY_ID'] = 'role-key'
         os.environ['AWS_SECRET_ACCESS_KEY'] = 'role-secret'
     

--- a/planscore/upload_fields.py
+++ b/planscore/upload_fields.py
@@ -49,26 +49,26 @@ def generate_signed_id(secret):
 def iam_user_env(environ):
     ''' Temporarily overwrite normal AWS role credentials for another AWS user.
     
-        Looks for "User_AWS_ACCESS_KEY" environment variable.
+        Looks for "Upload_AWS_*" environment variables.
     '''
     old_key, old_secret, old_token = None, None, None
 
-    if 'User_AWS_ACCESS_KEY_ID' in environ and 'User_AWS_SECRET_ACCESS_KEY' in environ:
+    if 'Upload_AWS_ACCESS_KEY_ID' in environ and 'Upload_AWS_SECRET_ACCESS_KEY' in environ:
         old_key = environ.get('AWS_ACCESS_KEY_ID')
         old_secret = environ.get('AWS_SECRET_ACCESS_KEY')
         old_token = environ.get('AWS_SESSION_TOKEN')
 
-        environ['AWS_ACCESS_KEY_ID'] = environ['User_AWS_ACCESS_KEY_ID']
-        environ['AWS_SECRET_ACCESS_KEY'] = environ['User_AWS_SECRET_ACCESS_KEY']
+        environ['AWS_ACCESS_KEY_ID'] = environ['Upload_AWS_ACCESS_KEY_ID']
+        environ['AWS_SECRET_ACCESS_KEY'] = environ['Upload_AWS_SECRET_ACCESS_KEY']
 
-        if 'User_AWS_SESSION_TOKEN' in environ:
-            environ['AWS_SESSION_TOKEN'] = environ['User_AWS_SESSION_TOKEN']
+        if 'Upload_AWS_SESSION_TOKEN' in environ:
+            environ['AWS_SESSION_TOKEN'] = environ['Upload_AWS_SESSION_TOKEN']
         elif 'AWS_SESSION_TOKEN' in environ:
             del environ['AWS_SESSION_TOKEN']
     
     yield
     
-    if 'User_AWS_ACCESS_KEY_ID' in environ and 'User_AWS_SECRET_ACCESS_KEY' in environ:
+    if 'Upload_AWS_ACCESS_KEY_ID' in environ and 'Upload_AWS_SECRET_ACCESS_KEY' in environ:
         environ['AWS_ACCESS_KEY_ID'] = old_key
         environ['AWS_SECRET_ACCESS_KEY'] = old_secret
         

--- a/planscore/website/templates/upload.html
+++ b/planscore/website/templates/upload.html
@@ -1,6 +1,7 @@
 {% extends "patternlibrary.html" %}
 {% block title %}Upload{% endblock %}
 {% block head %}
+    <meta http-equiv="refresh" content="240; url={{ url_for('get_upload') }}">
 	<script src="{{ digested_static_url('upload.js') }}"></script>
     <style lang="text/css">
     


### PR DESCRIPTION
Introduce key & secret for an IAM user that can only perform S3 uploads. Routes around the problem of expiring IAM roles when used in S3 pre-signed POSTs.