### PR TITLE
Issue 238 front page: click state = go to state

### DIFF
--- a/index.js6
+++ b/index.js6
@@ -382,7 +382,14 @@ window.loadDataForSelectedBoundaryAndYear = (options={}) => {
                     // click events: call the popup maker
                     events: {
                         click: function (e) {
-                            selectState(e.point.abbr, { closeIfSameState: true });
+// GDA issue 238 -- temporary measure to have a click proceed directly to the state page; if they choose to keep it, then selectState() goes away in favor of this
+// selectState(e.point.abbr, { closeIfSameState: true });
+                            // compose URL for the selected state + boundary + year (e.g. /california/#!2010-plan-ushouse) and send them to it
+                            // see the states page programming for details as to the expected hash params
+                            const plan_or_election = 'plan';
+                            const stateslug        = e.point.name.toLowerCase().replace(/\W/g, '_');
+                            const moreinfourl      = `/${stateslug}/#!${CURRENT_VIEW.year}-${plan_or_election}-${CURRENT_VIEW.boundtype}`;
+                            document.location.href = moreinfourl;
                         }
                     },
                 }]

--- a/index.js6
+++ b/index.js6
@@ -386,10 +386,17 @@ window.loadDataForSelectedBoundaryAndYear = (options={}) => {
 // selectState(e.point.abbr, { closeIfSameState: true });
                             // compose URL for the selected state + boundary + year (e.g. /california/#!2010-plan-ushouse) and send them to it
                             // see the states page programming for details as to the expected hash params
+                            // if they're holding the ctrl/alt/command key, try to open in a new window
                             const plan_or_election = 'plan';
                             const stateslug        = e.point.name.toLowerCase().replace(/\W/g, '_');
                             const moreinfourl      = `/${stateslug}/#!${CURRENT_VIEW.year}-${plan_or_election}-${CURRENT_VIEW.boundtype}`;
-                            document.location.href = moreinfourl;
+
+                            if (e.altKey || e.ctrlKey || e.shiftKey || e.metaKey) {
+                                window.open(moreinfourl);
+                            }
+                            else {
+                                document.location.href = moreinfourl;
+                            }
                         }
                     },
                 }]


### PR DESCRIPTION
This PR would bring in the behavior described in #238   On the front page, clicking a state would proceed directly to the given state+bound+year and there would be no popup.

Per #238 this intentionally leaves the current-behavior programming in place, until we decide which behavior is preferred.