### PR TITLE
Use new, faster tile-based scoring method instead of districts

### DIFF
--- a/planscore/after_upload.py
+++ b/planscore/after_upload.py
@@ -56,7 +56,7 @@ def commence_upload_scoring(s3, bucket, upload):
         else:
             ds_path = ul_path
         model = guess_state_model(ds_path)
-        score.put_upload_index(s3, bucket, upload)
+        observe.put_upload_index(s3, bucket, upload)
         put_geojson_file(s3, bucket, upload, ds_path)
         geometry_keys = put_district_geometries(s3, bucket, upload, ds_path)
         
@@ -290,10 +290,10 @@ def lambda_handler(event, context):
         commence_upload_scoring(s3, event['bucket'], upload)
     except RuntimeError as err:
         error_upload = upload.clone(message="Can't score this plan: {}".format(err))
-        score.put_upload_index(s3, event['bucket'], error_upload)
+        observe.put_upload_index(s3, event['bucket'], error_upload)
     except Exception:
         error_upload = upload.clone(message="Can't score this plan: something went wrong, giving up.")
-        score.put_upload_index(s3, event['bucket'], error_upload)
+        observe.put_upload_index(s3, event['bucket'], error_upload)
         raise
 
 if __name__ == '__main__':

--- a/planscore/after_upload.py
+++ b/planscore/after_upload.py
@@ -65,14 +65,14 @@ def commence_upload_scoring(s3, bucket, upload):
         district_blanks = [None] * len(geometry_keys)
         forward_upload = upload.clone(model=model, districts=district_blanks)
         
-        # Start up the old way first to preserve user experience
-        start_observer_score_lambda(storage, forward_upload)
-        fan_out_district_lambdas(bucket, model.key_prefix, forward_upload, geometry_keys)
-        
-        # New tile-based method is still pretty slow
+        # New tile-based method comes first to preserve user experience
         tile_keys = load_model_tiles(storage, forward_upload.model)
         start_tile_observer_lambda(storage, forward_upload, tile_keys)
         fan_out_tile_lambdas(storage, forward_upload, tile_keys)
+        
+        # Keep the old way around for the time being
+        start_observer_score_lambda(storage, forward_upload)
+        fan_out_district_lambdas(bucket, model.key_prefix, forward_upload, geometry_keys)
 
 def put_district_geometries(s3, bucket, upload, path):
     '''

--- a/planscore/callback.py
+++ b/planscore/callback.py
@@ -13,7 +13,7 @@ def create_upload(s3, bucket, key, id):
     '''
     upload = data.Upload(id, key, [],
         message='Scoring this newly-uploaded plan. Reload this page to see the result.')
-    observe.put_upload_index(s3, bucket, upload)
+    observe.put_upload_index(data.Storage(s3, bucket, None), upload)
     return upload
 
 def get_redirect_url(website_base, id):

--- a/planscore/callback.py
+++ b/planscore/callback.py
@@ -6,14 +6,14 @@ More details on "success_action_redirect" in browser-based S3 uploads:
     http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html
 '''
 import boto3, itsdangerous, urllib.parse, json
-from . import after_upload, constants, util, website, data, score
+from . import after_upload, constants, util, website, data, score, observe
 
 def create_upload(s3, bucket, key, id):
     '''
     '''
     upload = data.Upload(id, key, [],
         message='Scoring this newly-uploaded plan. Reload this page to see the result.')
-    score.put_upload_index(s3, bucket, upload)
+    observe.put_upload_index(s3, bucket, upload)
     return upload
 
 def get_redirect_url(website_base, id):

--- a/planscore/data.py
+++ b/planscore/data.py
@@ -46,6 +46,12 @@ class Progress:
     def to_list(self):
         return [self.completed, self.expected]
     
+    def to_percentage(self):
+        try:
+            return '{:.0f}%'.format(100 * self.completed / self.expected)
+        except ZeroDivisionError:
+            return '???%'
+    
     def is_complete(self):
         return bool(self.completed >= self.expected)
     

--- a/planscore/observe.py
+++ b/planscore/observe.py
@@ -7,14 +7,12 @@ FUNCTION_NAME = 'PlanScore-ObserveTiles'
 def put_upload_index(storage, upload):
     ''' Save a JSON index and a plaintext file for this upload.
     '''
-    key1 = 'uploads/{}/index-tiles.json'.format(upload.id)
+    key1 = upload.index_key()
     body1 = upload.to_json().encode('utf8')
 
     storage.s3.put_object(Bucket=storage.bucket, Key=key1, Body=body1,
         ContentType='text/json', ACL='public-read')
 
-    return
-    
     key2 = upload.plaintext_key()
     body2 = upload.to_plaintext().encode('utf8')
 

--- a/planscore/observe.py
+++ b/planscore/observe.py
@@ -72,8 +72,8 @@ def iterate_tile_totals(expected_tiles, storage, upload, context):
     for (index, expected_tile) in enumerate(expected_tiles):
         progress = data.Progress(index, len(expected_tiles))
         upload = upload.clone(progress=progress,
-            message='Scoring this newly-uploaded plan. {} of {} parts'
-                ' complete. Reload this page to see the result.'.format(*progress.to_list()))
+            message='Scoring this newly-uploaded plan. {} complete.'
+                ' Reload this page to see the result.'.format(progress.to_percentage()))
 
         # Update S3, if it's time
         if time.time() > next_update:

--- a/planscore/score.py
+++ b/planscore/score.py
@@ -235,12 +235,14 @@ def calculate_biases(upload):
 def put_upload_index(s3, bucket, upload):
     ''' Save a JSON index and a plaintext file for this upload.
     '''
-    key1 = upload.index_key()
+    key1 = 'uploads/{}/index-districts.json'.format(upload.id)
     body1 = upload.to_json().encode('utf8')
 
     s3.put_object(Bucket=bucket, Key=key1, Body=body1,
         ContentType='text/json', ACL='public-read')
 
+    return
+    
     key2 = upload.plaintext_key()
     body2 = upload.to_plaintext().encode('utf8')
 

--- a/planscore/tests/test_after_upload.py
+++ b/planscore/tests/test_after_upload.py
@@ -206,10 +206,9 @@ class TestAfterUpload (unittest.TestCase):
             ['data/XX/b.geojson', 'data/XX/c.geojson', 'data/XX/a.geojson',
             'data/XX/e.geojson', 'data/XX/d.geojson'][:constants.MAX_TILES_RUN])
     
-    @unittest.mock.patch('planscore.after_upload.load_model_tiles')
     @unittest.mock.patch('sys.stdout')
     @unittest.mock.patch('boto3.client')
-    def test_fan_out_tile_lambdas(self, boto3_client, stdout, load_model_tiles):
+    def test_fan_out_tile_lambdas(self, boto3_client, stdout):
         ''' Test that tile Lambda fan-out is invoked correctly.
         '''
         storage = unittest.mock.Mock()
@@ -218,16 +217,30 @@ class TestAfterUpload (unittest.TestCase):
 
         storage.to_event.return_value = None
         upload.model.to_dict.return_value = None
-        load_model_tiles.return_value = ['data/XX/a.geojson', 'data/XX/b.geojson']
 
-        after_upload.fan_out_tile_lambdas(storage, upload)
-        
-        load_model_tiles.assert_called_once_with(storage, upload.model)
+        after_upload.fan_out_tile_lambdas(storage, upload,
+            ['data/XX/a.geojson', 'data/XX/b.geojson'])
         
         invocations = boto3_client.return_value.invoke.mock_calls
         self.assertEqual(len(invocations), 2)
         self.assertIn(b'data/XX/a.geojson', invocations[0][2]['Payload'])
         self.assertIn(b'data/XX/b.geojson', invocations[1][2]['Payload'])
+    
+    @unittest.mock.patch('time.time')
+    @unittest.mock.patch('boto3.client')
+    def test_start_tile_observer_lambda(self, boto3_client, time_time):
+        '''
+        '''
+        storage, upload = unittest.mock.Mock(), unittest.mock.Mock()
+        storage.to_event.return_value = dict()
+        upload.to_dict.return_value = dict(start_time=1)
+        
+        after_upload.start_tile_observer_lambda(storage, upload,
+            ['data/XX/a.geojson', 'data/XX/b.geojson'])
+        
+        self.assertEqual(len(storage.s3.put_object.mock_calls), 1)
+        self.assertEqual(len(boto3_client.return_value.invoke.mock_calls), 1)
+        self.assertIn(b'"start_time": 1', boto3_client.return_value.invoke.mock_calls[0][2]['Payload'])
     
     @unittest.mock.patch('sys.stdout')
     @unittest.mock.patch('boto3.client')
@@ -274,8 +287,9 @@ class TestAfterUpload (unittest.TestCase):
     @unittest.mock.patch('planscore.after_upload.start_tile_observer_lambda')
     @unittest.mock.patch('planscore.after_upload.fan_out_tile_lambdas')
     @unittest.mock.patch('planscore.after_upload.start_observer_score_lambda')
+    @unittest.mock.patch('planscore.after_upload.load_model_tiles')
     @unittest.mock.patch('planscore.after_upload.guess_state_model')
-    def test_commence_upload_scoring_good_file(self, guess_state_model, start_observer_score_lambda, fan_out_tile_lambdas, start_tile_observer_lambda, fan_out_district_lambdas, put_district_geometries, put_geojson_file, put_upload_index, temporary_buffer_file):
+    def test_commence_upload_scoring_good_file(self, guess_state_model, load_model_tiles, start_observer_score_lambda, fan_out_tile_lambdas, start_tile_observer_lambda, fan_out_district_lambdas, put_district_geometries, put_geojson_file, put_upload_index, temporary_buffer_file):
         ''' A valid district plan file is scored and the results posted to S3
         '''
         id = 'ID'
@@ -306,9 +320,16 @@ class TestAfterUpload (unittest.TestCase):
         self.assertEqual(len(put_district_geometries.mock_calls), 1)
         self.assertEqual(put_district_geometries.mock_calls[0][1][3], nullplan_path)
 
+        self.assertEqual(len(load_model_tiles.mock_calls), 1)
+        
         self.assertEqual(len(fan_out_tile_lambdas.mock_calls), 1)
         self.assertIs(fan_out_tile_lambdas.mock_calls[0][1][0].s3, s3)
         self.assertIs(fan_out_tile_lambdas.mock_calls[0][1][1].id, upload.id)
+        self.assertIs(fan_out_tile_lambdas.mock_calls[0][1][2], load_model_tiles.return_value)
+
+        self.assertEqual(len(start_tile_observer_lambda.mock_calls), 1)
+        self.assertEqual(start_tile_observer_lambda.mock_calls[0][1][1].id, upload.id)
+        self.assertIs(start_tile_observer_lambda.mock_calls[0][1][2], load_model_tiles.return_value)
 
         self.assertEqual(len(fan_out_district_lambdas.mock_calls), 1)
         self.assertEqual(fan_out_district_lambdas.mock_calls[0][1][:2], (bucket, 'data/XX/003'))
@@ -327,8 +348,9 @@ class TestAfterUpload (unittest.TestCase):
     @unittest.mock.patch('planscore.after_upload.start_tile_observer_lambda')
     @unittest.mock.patch('planscore.after_upload.fan_out_tile_lambdas')
     @unittest.mock.patch('planscore.after_upload.start_observer_score_lambda')
+    @unittest.mock.patch('planscore.after_upload.load_model_tiles')
     @unittest.mock.patch('planscore.after_upload.guess_state_model')
-    def test_commence_upload_scoring_zipped_file(self, guess_state_model, start_observer_score_lambda, fan_out_tile_lambdas, start_tile_observer_lambda, fan_out_district_lambdas, put_district_geometries, unzip_shapefile, put_geojson_file, put_upload_index, temporary_buffer_file):
+    def test_commence_upload_scoring_zipped_file(self, guess_state_model, load_model_tiles, start_observer_score_lambda, fan_out_tile_lambdas, start_tile_observer_lambda, fan_out_district_lambdas, put_district_geometries, unzip_shapefile, put_geojson_file, put_upload_index, temporary_buffer_file):
         ''' A valid district plan zipfile is scored and the results posted to S3
         '''
         id = 'ID'
@@ -361,10 +383,17 @@ class TestAfterUpload (unittest.TestCase):
         
         self.assertEqual(len(put_district_geometries.mock_calls), 1)
         self.assertEqual(put_district_geometries.mock_calls[0][1][3], unzip_shapefile.return_value)
+
+        self.assertEqual(len(load_model_tiles.mock_calls), 1)
         
         self.assertEqual(len(fan_out_tile_lambdas.mock_calls), 1)
         self.assertIs(fan_out_tile_lambdas.mock_calls[0][1][0].s3, s3)
         self.assertIs(fan_out_tile_lambdas.mock_calls[0][1][1].id, upload.id)
+        self.assertIs(fan_out_tile_lambdas.mock_calls[0][1][2], load_model_tiles.return_value)
+        
+        self.assertEqual(len(start_tile_observer_lambda.mock_calls), 1)
+        self.assertEqual(start_tile_observer_lambda.mock_calls[0][1][1].id, upload.id)
+        self.assertIs(start_tile_observer_lambda.mock_calls[0][1][2], load_model_tiles.return_value)
 
         self.assertEqual(len(fan_out_district_lambdas.mock_calls), 1)
         self.assertEqual(fan_out_district_lambdas.mock_calls[0][1][:2], (bucket, 'data/XX/003'))

--- a/planscore/tests/test_after_upload.py
+++ b/planscore/tests/test_after_upload.py
@@ -51,7 +51,7 @@ class TestAfterUpload (unittest.TestCase):
         after_upload.lambda_handler(event, None)
         
         self.assertEqual(len(put_upload_index.mock_calls), 1)
-        self.assertEqual(put_upload_index.mock_calls[0][1][2].message,
+        self.assertEqual(put_upload_index.mock_calls[0][1][1].message,
             "Can't score this plan: Bad time")
     
     @unittest.mock.patch('sys.stdout')
@@ -314,7 +314,8 @@ class TestAfterUpload (unittest.TestCase):
         temporary_buffer_file.assert_called_once_with('null-plan.geojson', None)
         self.assertIsNone(info)
     
-        put_upload_index.assert_called_once_with(s3, bucket, upload)
+        self.assertEqual(len(put_upload_index.mock_calls), 1)
+        self.assertEqual(put_upload_index.mock_calls[0][1][1], upload)
         put_geojson_file.assert_called_once_with(s3, bucket, upload, nullplan_path)
         
         self.assertEqual(len(put_district_geometries.mock_calls), 1)
@@ -376,7 +377,8 @@ class TestAfterUpload (unittest.TestCase):
         temporary_buffer_file.assert_called_once_with('null-plan.shp.zip', None)
         self.assertIsNone(info)
     
-        put_upload_index.assert_called_once_with(s3, bucket, upload)
+        self.assertEqual(len(put_upload_index.mock_calls), 1)
+        self.assertEqual(put_upload_index.mock_calls[0][1][1], upload)
         
         self.assertEqual(put_geojson_file.mock_calls[0][1][:3], (s3, bucket, upload))
         self.assertIs(put_geojson_file.mock_calls[0][1][3], unzip_shapefile.return_value)

--- a/planscore/tests/test_after_upload.py
+++ b/planscore/tests/test_after_upload.py
@@ -33,7 +33,7 @@ class TestAfterUpload (unittest.TestCase):
         self.assertEqual(upload.id, event['id'])
         self.assertEqual(upload.key, event['key'])
     
-    @unittest.mock.patch('planscore.score.put_upload_index')
+    @unittest.mock.patch('planscore.observe.put_upload_index')
     @unittest.mock.patch('planscore.after_upload.commence_upload_scoring')
     def test_lambda_handler_failure(self, commence_upload_scoring, put_upload_index):
         ''' Lambda event triggers the right message after a failure
@@ -280,7 +280,7 @@ class TestAfterUpload (unittest.TestCase):
         self.assertIn(b'"start_time": 1', boto3_client.return_value.invoke.mock_calls[0][2]['Payload'])
     
     @unittest.mock.patch('planscore.util.temporary_buffer_file')
-    @unittest.mock.patch('planscore.score.put_upload_index')
+    @unittest.mock.patch('planscore.observe.put_upload_index')
     @unittest.mock.patch('planscore.after_upload.put_geojson_file')
     @unittest.mock.patch('planscore.after_upload.put_district_geometries')
     @unittest.mock.patch('planscore.after_upload.fan_out_district_lambdas')
@@ -340,7 +340,7 @@ class TestAfterUpload (unittest.TestCase):
         self.assertEqual(start_observer_score_lambda.mock_calls[0][1][1].id, upload.id)
     
     @unittest.mock.patch('planscore.util.temporary_buffer_file')
-    @unittest.mock.patch('planscore.score.put_upload_index')
+    @unittest.mock.patch('planscore.observe.put_upload_index')
     @unittest.mock.patch('planscore.after_upload.put_geojson_file')
     @unittest.mock.patch('planscore.util.unzip_shapefile')
     @unittest.mock.patch('planscore.after_upload.put_district_geometries')

--- a/planscore/tests/test_callback.py
+++ b/planscore/tests/test_callback.py
@@ -15,7 +15,7 @@ class TestCallback (unittest.TestCase):
         constants.S3_ENDPOINT_URL = self.prev_s3_url
         constants.LAMBDA_ENDPOINT_URL = self.prev_lam_url
     
-    @unittest.mock.patch('planscore.score.put_upload_index')
+    @unittest.mock.patch('planscore.observe.put_upload_index')
     def test_create_upload(self, put_upload_index):
         ''' create_upload() makes the right call to put_upload_index().
         '''

--- a/planscore/tests/test_callback.py
+++ b/planscore/tests/test_callback.py
@@ -23,11 +23,12 @@ class TestCallback (unittest.TestCase):
         callback.create_upload(s3, bucket, 'example-key', 'example-id')
         
         self.assertEqual(len(put_upload_index.mock_calls), 1)
-        self.assertEqual(len(put_upload_index.mock_calls[0][1]), 3)
+        self.assertEqual(len(put_upload_index.mock_calls[0][1]), 2)
         
-        self.assertEqual(put_upload_index.mock_calls[0][1][:2], (s3, bucket))
-        self.assertEqual(put_upload_index.mock_calls[0][1][2].id, 'example-id')
-        self.assertEqual(put_upload_index.mock_calls[0][1][2].key, 'example-key')
+        self.assertEqual(put_upload_index.mock_calls[0][1][0].s3, s3)
+        self.assertEqual(put_upload_index.mock_calls[0][1][0].bucket, bucket)
+        self.assertEqual(put_upload_index.mock_calls[0][1][1].id, 'example-id')
+        self.assertEqual(put_upload_index.mock_calls[0][1][1].key, 'example-key')
 
     @unittest.mock.patch('planscore.callback.create_upload')
     @unittest.mock.patch('boto3.client')

--- a/planscore/tests/test_data.py
+++ b/planscore/tests/test_data.py
@@ -21,6 +21,12 @@ class TestData (unittest.TestCase):
         self.assertFalse(p1.is_complete())
         self.assertTrue(p2.is_complete())
         self.assertTrue(p3.is_complete())
+        
+        self.assertEqual(p1.to_list(), [1, 2])
+        self.assertEqual(p1.to_percentage(), '50%')
+
+        p4 = data.Progress(0, 0)
+        self.assertEqual(p4.to_percentage(), '???%')
     
     def test_model(self):
         '''

--- a/planscore/tests/test_observe.py
+++ b/planscore/tests/test_observe.py
@@ -23,17 +23,14 @@ class TestObserveTiles (unittest.TestCase):
         ''' Upload index file is posted to S3
         '''
         storage, upload = unittest.mock.Mock(), unittest.mock.Mock()
-        upload.id = 'ID'
         observe.put_upload_index(storage, upload)
         
-        (put_call1, ) = storage.s3.put_object.mock_calls
+        put_call1, put_call2 = storage.s3.put_object.mock_calls
         
         self.assertEqual(put_call1[2], dict(Bucket=storage.bucket,
-            Key='uploads/ID/index-tiles.json',
+            Key=upload.index_key.return_value,
             Body=upload.to_json.return_value.encode.return_value,
             ACL='public-read', ContentType='text/json'))
-        
-        return
         
         self.assertEqual(put_call2[2], dict(Bucket=storage.bucket,
             Key=upload.plaintext_key.return_value,

--- a/planscore/tests/test_score.py
+++ b/planscore/tests/test_score.py
@@ -286,14 +286,17 @@ class TestScore (unittest.TestCase):
         ''' Upload index file is posted to S3
         '''
         s3, bucket, upload = unittest.mock.Mock(), unittest.mock.Mock(), unittest.mock.Mock()
+        upload.id = 'ID'
         score.put_upload_index(s3, bucket, upload)
         
-        put_call1, put_call2 = s3.put_object.mock_calls
+        (put_call1, ) = s3.put_object.mock_calls
         
         self.assertEqual(put_call1[2], dict(Bucket=bucket,
-            Key=upload.index_key.return_value,
+            Key='uploads/ID/index-districts.json',
             Body=upload.to_json.return_value.encode.return_value,
             ACL='public-read', ContentType='text/json'))
+        
+        return
         
         self.assertEqual(put_call2[2], dict(Bucket=bucket,
             Key=upload.plaintext_key.return_value,


### PR DESCRIPTION
Parallelize on hundreds of tiles instead of dozens of districts. Keep the old way around just in case, for now.