### PR TITLE
Added NC-only table with 2016/18 U.S. House details

### DIFF
--- a/north_carolina/index.js6
+++ b/north_carolina/index.js6
@@ -280,6 +280,11 @@ window.initLoadStartingConditions = () => {
     selectMetric(metric);
     selectElectionOrPlan(year, planyear);
     selectBoundaryType(district);
+
+    if(SELECTED_STATE + district == 'North Carolina' + 'ushouse')
+    {
+        document.getElementById('special-NC-pre-2018').style.display = 'block';
+    }
 };
 
 

--- a/north_carolina/index.src.html
+++ b/north_carolina/index.src.html
@@ -214,6 +214,57 @@
                     <p>No plan data are available for the selected year for this district type.</p>
                     <p>The closest we have to the year you asked for is <a href="javascript:void(0);" data-year="" onClick="selectElectionOrPlan(this.getAttribute('data-year'));"><span data-field="closestyear">YYYY</span></a>.</p>
                 </span>
+
+            </div>
+        </div>
+        <div class="row" style="margin-top: 20px">
+            <div id="special-NC-pre-2018" style="display: none" class="col-xs-12 col-sm-offset-3 col-sm-9">
+                <h2>2018 U.S. House Results</h2>
+                <p>Comparison of how North Carolina’s 2016 Redistricting Plan performed in 2016 and in 2018:</p>
+                <div class="table-responsive col-xs-12 col-sm-12">
+                    <table class="table table-hover"> 
+                        <thead>
+                            <tr>
+                                <th></th>
+                                <th>2016</th>
+                                <th>2018</th>
+                            </tr> 
+                        </thead> 
+                        <tbody> 
+                            <tr>
+                                <th scope="row">Democratic Vote Share</th>
+                                <td>46.7%</td>
+                                <td>50.8%</td>
+                            </tr> 
+                            <tr>
+                                <th scope="row">Democratic Seats</th>
+                                <td>3/13</td>
+                                <td>3/13</td>
+                            </tr>
+                            <tr>
+                                <th scope="row">Democratic Seat Share</th>
+                                <td>23.1%</td>
+                                <td>23.1%</td>
+                            </tr>
+                            <tr>
+                                <th scope="row">Efficiency Gap</th>
+                                <td>-19.4%</td>
+                                <td>-27.7%</td>
+                            </tr> 
+                            <tr>
+                                <th scope="row">Partisan Bias</th>
+                                <td>-26.9%</td>
+                                <td>-26.9%</td>
+                            </tr>
+                            <tr>
+                                <th scope="row">Mean-Median Difference</th>
+                                <td>-5.1%</td>
+                                <td>-5.8%</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
             </div>
         </div>
 


### PR DESCRIPTION
This very hacky approach introduces a North Carolina table that’s only shown when NC + U.S. House are selected.