### PR TITLE
Upgrade localstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ AWS development stack [LocalStack](https://github.com/localstack/localstack).
     
 7.  In a separate window, run LocalStack.
     
-        env SERVICES=s3,lambda LAMBDA_EXECUTOR=docker localstack start
+        env SERVICES=s3,lambda,apigateway LAMBDA_EXECUTOR=docker localstack start --host
     
     Wait for the expected output.
     

--- a/deploy.py
+++ b/deploy.py
@@ -39,6 +39,7 @@ api_integrations = {
         #requestParameters={'integration.request.querystring.layer': 'method.request.querystring.layer'},
         ),
     }
+
 def publish_function(lam, name, path, env, role):
     ''' Create or update the named function to Lambda, return its ARN.
     '''
@@ -71,11 +72,9 @@ def publish_function(lam, name, path, env, role):
     
     return arn
 
-def update_api(api, api_name, function_arn, function_name, role):
+def prepare_api(api, api_name):
     '''
     '''
-    path = api_paths[function_name]
-    
     try:
         print('    * get API', api_name, file=sys.stderr)
         rest_api = [item for item in api.get_rest_apis()['items']
@@ -87,7 +86,15 @@ def update_api(api, api_name, function_arn, function_name, role):
         rest_api_id = rest_api['id']
         api_kwargs = dict(restApiId=rest_api_id,
             parentId=api.get_resources(restApiId=rest_api_id)['items'][0]['id'])
+    
+    return rest_api_id, api_kwargs
 
+def update_api(api, api_name, function_arn, function_name, role):
+    '''
+    '''
+    path = api_paths[function_name]
+    rest_api_id, api_kwargs = prepare_api(api, api_name)
+    
     try:
         print('    * get resource', rest_api_id, path, file=sys.stderr)
         resource = [item for item in api.get_resources(restApiId=rest_api_id)['items']

--- a/planscore/constants.py
+++ b/planscore/constants.py
@@ -25,7 +25,7 @@ SECRET = os.environ.get('PLANSCORE_SECRET', 'fake')
 # S3 bucket name, which should generally be left alone.
 S3_BUCKET = os.environ.get('S3_BUCKET', 'planscore')
 
-# API Gateway name
+# API Gateway name, which should generally be left alone.
 API_NAME = 'PlanScore'
 
 # Relative URL paths for AWS Lambda functions.
@@ -59,12 +59,12 @@ if os.environ.get('AWS') == 'amazonaws.com':
 #
 # Used to coordinate links, form actions, and redirects between Flask app
 # and Lambda functions. In production, these will be set to values such as
-# 'http://planscore.org/'.
+# 'https://planscore.org/' and 'https://api.planscore.org/'.
 
 WEBSITE_BASE = os.environ.get('WEBSITE_BASE')
 API_BASE = os.environ.get('API_BASE')
 
-if os.environ.get('AWS') != 'amazonaws.com':
+if not (os.environ.get('AWS') == 'amazonaws.com' or API_BASE):
     try:
         API_BASE = localstack_api_base(API_ENDPOINT_URL, API_NAME)
     except:

--- a/planscore/constants.py
+++ b/planscore/constants.py
@@ -31,13 +31,8 @@ S3_BUCKET = os.environ.get('S3_BUCKET', 'planscore')
 # API Gateway name, which should generally be left alone.
 API_NAME = 'PlanScore'
 
-# Relative URL paths for AWS Lambda functions.
-#
-# These values interact with environment variables like WEBSITE_BASE and
-# API_BASE via URL path joins. When developing locally, Lambda URLs will look
-# like 'http://127.0.0.1:5000/localstack/upload' for use with localstack mock
-# services. In production, Lamdba URLs will look like
-# 'https://api.planscore.org/upload'.
+# Relative URL paths for AWS Lambda functions. These values interact with
+# environment variables like WEBSITE_BASE and API_BASE via URL path joins.
 
 API_UPLOAD_RELPATH = 'upload'
 API_UPLOADED_RELPATH = 'uploaded'
@@ -62,7 +57,9 @@ if os.environ.get('AWS') == 'amazonaws.com':
 #
 # Used to coordinate links, form actions, and redirects between Flask app
 # and Lambda functions. In production, these will be set to values such as
-# 'https://planscore.org/' and 'https://api.planscore.org/'.
+# 'https://planscore.org/' and 'https://api.planscore.org/'. When running
+# without AWS='amazonaws.com' and a defined API_BASE env var, inspect
+# localstack API Gateway to find correct API base URL value.
 
 WEBSITE_BASE = os.environ.get('WEBSITE_BASE')
 API_BASE = os.environ.get('API_BASE')

--- a/planscore/constants.py
+++ b/planscore/constants.py
@@ -15,6 +15,9 @@ SECRET = os.environ.get('PLANSCORE_SECRET', 'fake')
 # S3 bucket name, which should generally be left alone.
 S3_BUCKET = os.environ.get('S3_BUCKET', 'planscore')
 
+# API Gateway name
+API_NAME = 'PlanScore'
+
 # Website and API URLs.
 #
 # Used to coordinate links, form actions, and redirects between Flask app

--- a/planscore/constants.py
+++ b/planscore/constants.py
@@ -44,10 +44,11 @@ API_UPLOADED_RELPATH = 'uploaded'
 
 S3_ENDPOINT_URL = os.environ.get('S3_ENDPOINT_URL', _local_url(4572))
 LAMBDA_ENDPOINT_URL = os.environ.get('LAMBDA_ENDPOINT_URL', _local_url(4574))
+API_ENDPOINT_URL = os.environ.get('API_ENDPOINT_URL', _local_url(4567))
 S3_URL_PATTERN = urllib.parse.urljoin(S3_ENDPOINT_URL, '/{b}/{k}')
 
 if os.environ.get('AWS') == 'amazonaws.com':
-    S3_ENDPOINT_URL, LAMBDA_ENDPOINT_URL = None, None
+    S3_ENDPOINT_URL, LAMBDA_ENDPOINT_URL, API_ENDPOINT_URL = None, None, None
     S3_URL_PATTERN = 'https://{b}.s3.amazonaws.com/{k}'
 
 # Time limit to process an upload, in seconds

--- a/planscore/constants.py
+++ b/planscore/constants.py
@@ -6,7 +6,10 @@ def _local_url(port):
         Host addresses will be different from localhost or 127.0.0.1, so that
         localstack S3 can be accessible from localstack Lambda in Docker.
     '''
-    host_address = socket.gethostbyname(socket.gethostname())
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.connect(('8.8.8.8', 8)) # don't need to actually connect...
+        host_address, _ = s.getsockname() # ...just need a local network address
+
     return 'http://{}:{}'.format(host_address, port)
 
 @functools.lru_cache()

--- a/planscore/tests/test_util.py
+++ b/planscore/tests/test_util.py
@@ -79,7 +79,10 @@ class TestUtil (unittest.TestCase):
         for filename in ('null-plan.dbf', 'null-plan.prj', 'null-plan.shp', 'null-plan.shx'):
             self.assertTrue(os.path.exists(os.path.join(self.tempdir, filename)))
     
-    def test_event_url(self):
+    @unittest.mock.patch('planscore.util.localstack_api_base')
+    def test_event_url(self, localstack_api_base):
+        constants.API_ENDPOINT_URL = None
+    
         url1 = util.event_url({'headers': {'Host': 'example.org'}})
         self.assertEqual(url1, 'http://example.org/')
 
@@ -88,6 +91,15 @@ class TestUtil (unittest.TestCase):
 
         url3 = util.event_url({'headers': {'Host': 'example.org'}, 'path': '/hello'})
         self.assertEqual(url3, 'http://example.org/hello')
+
+        constants.API_ENDPOINT_URL = 'http://aws.example.com'
+        localstack_api_base.return_value = 'http://aws.example.com/stuff/'
+    
+        url4 = util.event_url({'path': '/hello'})
+        self.assertEqual(url4, 'http://aws.example.com/stuff/hello')
+        
+        localstack_api_base.assert_called_once_with(
+            constants.API_ENDPOINT_URL, constants.API_NAME)
     
     def test_event_query_args(self):
         args1 = util.event_query_args({})

--- a/planscore/tests/test_util.py
+++ b/planscore/tests/test_util.py
@@ -79,7 +79,7 @@ class TestUtil (unittest.TestCase):
         for filename in ('null-plan.dbf', 'null-plan.prj', 'null-plan.shp', 'null-plan.shx'):
             self.assertTrue(os.path.exists(os.path.join(self.tempdir, filename)))
     
-    @unittest.mock.patch('planscore.util.localstack_api_base')
+    @unittest.mock.patch('planscore.constants.localstack_api_base')
     def test_event_url(self, localstack_api_base):
         constants.API_ENDPOINT_URL = None
     

--- a/planscore/tests/test_website.py
+++ b/planscore/tests/test_website.py
@@ -1,4 +1,4 @@
-import unittest, os
+import unittest, unittest.mock, os
 from .. import website, constants
 
 class TestWebsite (unittest.TestCase):
@@ -20,3 +20,14 @@ class TestWebsite (unittest.TestCase):
         html = self.app.get('/plan.html?12345').data.decode('utf8')
         self.assertIn(constants.S3_URL_PATTERN.format(b='fake-bucket', k='uploads/{id}/index.json'), html)
         self.assertIn(constants.S3_URL_PATTERN.format(b='fake-bucket', k='uploads/{id}/geometry.json'), html)
+    
+    @unittest.mock.patch('flask.current_app')
+    def test_get_function_url(self, current_app):
+        current_app.config = dict(PLANSCORE_API_BASE='http://example.com/yolo/')
+
+        url1 = website.get_function_url('good-times')
+        self.assertEqual(url1, 'http://example.com/yolo/good-times')
+
+        url2 = website.get_function_url('/good-times')
+        self.assertEqual(url2, 'http://example.com/good-times')
+        

--- a/planscore/util.py
+++ b/planscore/util.py
@@ -50,6 +50,9 @@ def event_url(event):
     hostname = event.get('headers', {}).get('Host', 'example.com')
     path = event.get('path', '/')
     
+    if constants.API_ENDPOINT_URL:
+        return urllib.parse.urljoin(constants.API_ENDPOINT_URL, path.lstrip('/'))
+    
     return urllib.parse.urlunparse((scheme, hostname, path, None, None, None))
 
 def event_query_args(event):

--- a/planscore/util.py
+++ b/planscore/util.py
@@ -1,4 +1,4 @@
-import urllib.parse, tempfile, shutil, os, contextlib, logging, zipfile, itertools, shutil
+import urllib.parse, tempfile, shutil, os, contextlib, logging, zipfile, itertools, shutil, functools
 import boto3
 from . import constants
 
@@ -43,16 +43,27 @@ def unzip_shapefile(zip_path, zip_dir):
     
     return unzipped_path
 
+@functools.lru_cache()
+def localstack_api_base(API_ENDPOINT_URL, API_NAME):
+    '''
+    '''
+    api = boto3.client('apigateway', endpoint_url=API_ENDPOINT_URL)
+    rest_api_id = [item for item in api.get_rest_apis()['items']
+                   if item['name'] == API_NAME][0]['id']
+    return f'{api._endpoint.host}/restapis/{rest_api_id}/test/_user_request_/'
+
 def event_url(event):
     '''
     '''
-    scheme = event.get('headers', {}).get('X-Forwarded-Proto', 'http')
-    hostname = event.get('headers', {}).get('Host', 'example.com')
     path = event.get('path', '/')
     
     if constants.API_ENDPOINT_URL:
-        return urllib.parse.urljoin(constants.API_ENDPOINT_URL, path.lstrip('/'))
+        api_base = localstack_api_base(constants.API_ENDPOINT_URL, constants.API_NAME)
+        return urllib.parse.urljoin(api_base, path.lstrip('/'))
     
+    scheme = event.get('headers', {}).get('X-Forwarded-Proto', 'http')
+    hostname = event.get('headers', {}).get('Host', 'example.com')
+
     return urllib.parse.urlunparse((scheme, hostname, path, None, None, None))
 
 def event_query_args(event):

--- a/planscore/util.py
+++ b/planscore/util.py
@@ -1,5 +1,4 @@
-import urllib.parse, tempfile, shutil, os, contextlib, logging, zipfile, itertools, shutil, functools
-import boto3
+import urllib.parse, tempfile, shutil, os, contextlib, logging, zipfile, itertools, shutil
 from . import constants
 
 @contextlib.contextmanager
@@ -43,22 +42,13 @@ def unzip_shapefile(zip_path, zip_dir):
     
     return unzipped_path
 
-@functools.lru_cache()
-def localstack_api_base(API_ENDPOINT_URL, API_NAME):
-    '''
-    '''
-    api = boto3.client('apigateway', endpoint_url=API_ENDPOINT_URL)
-    rest_api_id = [item for item in api.get_rest_apis()['items']
-                   if item['name'] == API_NAME][0]['id']
-    return f'{api._endpoint.host}/restapis/{rest_api_id}/test/_user_request_/'
-
 def event_url(event):
     '''
     '''
     path = event.get('path', '/')
     
     if constants.API_ENDPOINT_URL:
-        api_base = localstack_api_base(constants.API_ENDPOINT_URL, constants.API_NAME)
+        api_base = constants.localstack_api_base(constants.API_ENDPOINT_URL, constants.API_NAME)
         return urllib.parse.urljoin(api_base, path.lstrip('/'))
     
     scheme = event.get('headers', {}).get('X-Forwarded-Proto', 'http')

--- a/setup-localstack.py
+++ b/setup-localstack.py
@@ -77,10 +77,13 @@ print('--> Set up Lambda', ENDPOINT_LAM)
 lam = boto3.client('lambda', endpoint_url=ENDPOINT_LAM, region_name='us-east-1', **AWS_CREDS)
 api = boto3.client('apigateway', endpoint_url=ENDPOINT_API, region_name='us-east-1', **AWS_CREDS)
 
+rest_api_id, _ = deploy.prepare_api(api, 'PlanScore')
+api_base = f'{api._endpoint.host}/restapis/{rest_api_id}/test/_user_request_/'
+
 env = {
     'PLANSCORE_SECRET': 'localstack',
     'WEBSITE_BASE': 'http://127.0.0.1:5000/',
-    'API_BASE': urllib.parse.urljoin(ENDPOINT_API, '/restapis/dtozykecfh/test/_user_request_/'),
+    'API_BASE': api_base,
     'S3_ENDPOINT_URL': ENDPOINT_S3,
     'LAMBDA_ENDPOINT_URL': ENDPOINT_LAM,
     'API_ENDPOINT_URL': ENDPOINT_API,

--- a/setup-localstack.py
+++ b/setup-localstack.py
@@ -83,6 +83,7 @@ env = {
     'API_BASE': urllib.parse.urljoin(ENDPOINT_API, '/restapis/dtozykecfh/test/_user_request_/'),
     'S3_ENDPOINT_URL': ENDPOINT_S3,
     'LAMBDA_ENDPOINT_URL': ENDPOINT_LAM,
+    'API_ENDPOINT_URL': ENDPOINT_API,
     }
 
 print('    Environment:', ' '.join(['='.join(kv) for kv in env.items()]))
@@ -90,7 +91,7 @@ print('    Environment:', ' '.join(['='.join(kv) for kv in env.items()]))
 for function_name in deploy.functions.keys():
     arn = deploy.publish_function(lam, function_name, CODE_PATH, env, 'nobody')
     if function_name not in deploy.api_methods:
-        print('   - No API Gateway for', function_name, file=sys.stderr)
+        print('    - No API Gateway for', function_name, file=sys.stderr)
         continue
     rest_api_id = deploy.update_api(api, 'PlanScore', arn, function_name, 'nobody')
     time.sleep(random.randint(0, 5))

--- a/setup-localstack.py
+++ b/setup-localstack.py
@@ -9,7 +9,9 @@ arguments = parser.parse_args()
 
 # Names of things
 
-host_address = socket.gethostbyname(socket.gethostname())
+with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+    s.connect(('8.8.8.8', 8)) # don't need to actually connect...
+    host_address, _ = s.getsockname() # ...just need a local network address
 
 BUCKETNAME = 'planscore'
 ENDPOINT_S3 = 'http://{}:4572'.format(host_address)


### PR DESCRIPTION
New versions of [localstack](https://github.com/localstack/localstack) include an implementation of API Gateway so stop using a Flask proxy implementation. Add method and integration updates to deployment script, and get slightly smarter about localstack URLs.