### PR TITLE
Pin HighMaps.js version

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -6,7 +6,7 @@
     <!--[include_head]-->
 
     <!-- Highcharts does charts and also maps -->
-    <script src="https://code.highcharts.com/maps/highmaps.js"></script>
+    <script src="https://code.highcharts.com/maps/8.0.4/highmaps.js"></script>
     <script src="https://code.highcharts.com/maps/modules/data.js"></script>
     <script src="/data/usmapchart.json"></script>
 


### PR DESCRIPTION
Callout states suddenly missing due to a recent change in HighMaps. 

A one-line change to pin to 8.0.4 fixes the issue in local testing, but we need a refresher on how the CI setup works -- I got a failing build notification from circleCI on this branch, and my assumption is that if we merged into `static-site` we would see the same issue, though not sure.

Here's the error:
![image](https://user-images.githubusercontent.com/1423200/82249470-aa083080-98fe-11ea-9960-29e2ebd3017a.png)
