### PR TITLE
Handle scoring of districts with no votes

### DIFF
--- a/planscore/matrix.py
+++ b/planscore/matrix.py
@@ -73,7 +73,7 @@ def apply_model(districts, model):
         - -1 for Republican, 0 for open seat, and 1 for Democratic incumbents
     '''
     AD = numpy.array([
-        [1, vote + VOTE_ADJUST, incumbency] * 3
+        [1, numpy.nan if numpy.isnan(vote) else (vote + VOTE_ADJUST), incumbency] * 3
         for (vote, incumbency)
         in districts
     ])
@@ -94,7 +94,8 @@ def model_votes(state, year, districts):
     # Get DxS array from apply_model() with modeled vote fractions
     fractions = apply_model(
         [
-            (dem / (dem + rep), INCUMBENCY[inc]) for (dem, rep, inc) in districts
+            (dem / ((dem + rep) or numpy.nan), INCUMBENCY[inc])
+            for (dem, rep, inc) in districts
         ],
         load_model(STATE[state], year),
     )

--- a/planscore/matrix.py
+++ b/planscore/matrix.py
@@ -115,4 +115,7 @@ def model_votes(state, year, districts):
         axis=2,
     )
     
+    # Set all the NaNs to zeros
+    votes[numpy.isnan(votes)] = 0
+    
     return votes

--- a/planscore/tests/test_matrix.py
+++ b/planscore/tests/test_matrix.py
@@ -140,4 +140,4 @@ class TestMatrix (unittest.TestCase):
             [4.0, 6.0],
         ])
         
-        self.assertTrue(numpy.isnan(R[1]).all())
+        self.assertEqual(R[1].sum(), 0)

--- a/planscore/tests/test_matrix.py
+++ b/planscore/tests/test_matrix.py
@@ -63,6 +63,20 @@ class TestMatrix (unittest.TestCase):
         self.assertTrue(R[1].sum() < R[4].sum() and R[4].sum() < R[7].sum())
         self.assertTrue(R[2].sum() < R[5].sum() and R[5].sum() < R[8].sum())
     
+    def test_apply_model_with_zeros(self):
+        model = matrix.load_model('ca', '2012')
+        
+        R = matrix.apply_model(
+            [
+                (numpy.nan, -1),
+                (numpy.nan, 1),
+                (numpy.nan, 0),
+            ],
+            model,
+        )
+        
+        self.assertTrue(numpy.isnan(R).all(), 'Everything should be NaN')
+    
     @unittest.mock.patch('planscore.matrix.load_model')
     @unittest.mock.patch('planscore.matrix.apply_model')
     def test_model_votes(self, apply_model, load_model):
@@ -95,3 +109,35 @@ class TestMatrix (unittest.TestCase):
             [[6.0, 4.0],
              [7.0, 3.0]],
         ])
+    
+    @unittest.mock.patch('planscore.matrix.load_model')
+    @unittest.mock.patch('planscore.matrix.apply_model')
+    def test_model_votes_with_zeros(self, apply_model, load_model):
+        apply_model.return_value = numpy.array([
+            [0.3, 0.4],
+            [numpy.nan, numpy.nan]
+        ])
+
+        R = matrix.model_votes(
+            data.State.NC,
+            2016,
+            [
+                (4, 6, 'R'),
+                (0, 0, 'O'),
+            ],
+        )
+
+        # Can't just check NaN == NaN
+        self.assertEqual(apply_model.mock_calls[0][1][0][0], (.4, -1))
+        self.assertTrue(numpy.isnan(apply_model.mock_calls[0][1][0][1][0]))
+        self.assertEqual(apply_model.mock_calls[0][1][0][1][1], 0)
+        self.assertEqual(apply_model.mock_calls[0][1][1], load_model.return_value)
+        
+        self.assertEqual(load_model.mock_calls[0][1], ('nc', 2016))
+
+        self.assertEqual(R[0].tolist(), [
+            [3.0, 7.0],
+            [4.0, 6.0],
+        ])
+        
+        self.assertTrue(numpy.isnan(R[1]).all())

--- a/planscore/tests/test_score.py
+++ b/planscore/tests/test_score.py
@@ -735,3 +735,60 @@ class TestScore (unittest.TestCase):
         ])
         output = score.calculate_district_biases(score.calculate_biases(score.calculate_open_biases(score.calculate_bias(input))))
         self.assertEqual(model_votes.mock_calls[0][1], (data.State.XX, 2016, [(6, 2, 'R'), (5, 3, 'D'), (3, 5, 'R'), (2, 6, 'D')]))
+
+    @unittest.mock.patch('planscore.score.calculate_MMD')
+    @unittest.mock.patch('planscore.score.calculate_PB')
+    @unittest.mock.patch('planscore.score.calculate_EG')
+    @unittest.mock.patch('planscore.matrix.model_votes')
+    def test_calculate_gap_with_zeros(self, model_votes, calculate_EG, calculate_PB, calculate_MMD):
+        ''' Efficiency gap can be correctly calculated from presidential vote only
+        '''
+        input = data.Upload(id=None, key=None,
+            model = data.Model(data.State.XX, data.House.ushouse, 4, False, '2020', None),
+            districts = [
+                dict(totals={'US President 2016 - REP': 2, 'US President 2016 - DEM': 6}, tile=None),
+                dict(totals={'US President 2016 - REP': 0, 'US President 2016 - DEM': 0}, tile=None),
+                ])
+        
+        calculate_MMD.return_value = 0
+        calculate_PB.return_value = 0
+        calculate_EG.return_value = 0
+        model_votes.return_value = numpy.array([
+            [[5.3, 2.7],
+             [6.0, 2.0],
+             [5.9, 2.1]],
+
+            [[0.0, 0.0],
+             [0.0, 0.0],
+             [0.0, 0.0]],
+        ])
+        output = score.calculate_district_biases(score.calculate_biases(score.calculate_open_biases(score.calculate_bias(input))))
+        self.assertEqual(model_votes.mock_calls[0][1], (data.State.XX, 2016, [(6, 2, 'O'), (0, 0, 'O')]))
+        
+        self.assertEqual(output.summary['Mean-Median'], calculate_MMD.return_value)
+        self.assertEqual(calculate_MMD.mock_calls[0][1], ([2.7, 0.0], [5.3, 0.0]))
+
+        self.assertEqual(output.summary['Partisan Bias'], calculate_PB.return_value)
+        self.assertEqual(calculate_PB.mock_calls[0][1], ([2.7, 0.0], [5.3, 0.0]))
+        
+        SIMS = model_votes.return_value.shape[1]
+
+        # First round of sims
+        self.assertEqual(output.summary['Efficiency Gap'], calculate_EG.return_value)
+        self.assertEqual(calculate_EG.mock_calls[SIMS*0][1], ([2.7, 0.0], [5.3, 0.0], 0.))
+
+        # Second round of sims
+        self.assertEqual(output.summary['Efficiency Gap +1 Dem'], calculate_EG.return_value)
+        self.assertEqual(calculate_EG.mock_calls[SIMS*1][1], ([2.7, 0.0], [5.3, 0.0], .01))
+
+        # Third round of sims
+        self.assertEqual(output.summary['Efficiency Gap +1 Rep'], calculate_EG.return_value)
+        self.assertEqual(calculate_EG.mock_calls[SIMS*2][1], ([2.7, 0.0], [5.3, 0.0], -.01))
+
+        self.assertEqual(output.districts[0]['totals']['Republican Votes'], 2.27)
+        self.assertEqual(output.districts[0]['totals']['Democratic Votes'], 5.73)
+        self.assertEqual(output.districts[1]['totals']['Republican Votes'], 0.0)
+        self.assertEqual(output.districts[1]['totals']['Democratic Votes'], 0.0)
+
+        self.assertAlmostEqual(output.districts[0]['totals']['Democratic Wins'], 1.)
+        self.assertAlmostEqual(output.districts[1]['totals']['Democratic Wins'], 0.)


### PR DESCRIPTION
Uploaded plans may include blank districts, such as the all-water fake districts included with U.S. Census shapefiles.