### PR TITLE
add hover interaction between map and table rows

### DIFF
--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -876,7 +876,7 @@ function load_plan_score(url, message_section, score_section,
         }
 
         // Go on to load the map.
-        load_plan_map(geom_prefix + plan.geometry_key, map_div, plan);
+        load_plan_map(geom_prefix + plan.geometry_key, map_div, plan, table);
     }
 
     request.onload = function()
@@ -905,7 +905,7 @@ function load_plan_score(url, message_section, score_section,
     request.send();
 }
 
-function load_plan_map(url, div, plan)
+function load_plan_map(url, div, plan, table)
 {
     var request = new XMLHttpRequest();
     request.open('GET', url, true);
@@ -933,16 +933,33 @@ function load_plan_map(url, div, plan)
                 return { weight: 2, fillOpacity: .5, color: which_district_color(district, plan) };
             }
             }).bindPopup(district_popup_content);
+        window.the_geojson = geojson;
+        window.the_data = data;
 
 
-        function on_mouse_event(evtdata) {
-            const apply_highlight = evtdata.type === 'mouseover';
+        // On map layer hover: highlight associated table rows 
+        function on_geojson_mouse_event(evtdata) {
+            const should_apply_highlight = evtdata.type === 'mouseover';
             const index = data.features.indexOf(evtdata.layer.feature);
             const tableRowEl = $('table tbody tr').get(index);
-            tableRowEl.classList.toggle('highlighted', apply_highlight);
+            tableRowEl.classList.toggle('highlighted', should_apply_highlight);
         }
-        geojson.on('mouseover', on_mouse_event);
-        geojson.on('mouseout', on_mouse_event);
+        geojson.on('mouseover', on_geojson_mouse_event);
+        geojson.on('mouseout', on_geojson_mouse_event);
+
+
+        // On table row hover: highlight map district
+        table.querySelectorAll('tbody tr').forEach((elem, j) => {
+            const on_tr_mouse_event = e => {
+                const should_apply_highlight = e.type === 'mouseover';
+                const matched_feature = data.features[j];
+                const layer = Object.values(geojson._layers).find(l => l.feature === matched_feature);
+                const path_elem = layer['_path'];
+                path_elem.classList.toggle('highlight', should_apply_highlight);
+            };
+            elem.addEventListener('mouseover', on_tr_mouse_event);
+            elem.addEventListener('mouseout', on_tr_mouse_event);
+        });
 
         console.log('GeoJSON bounds:', geojson.getBounds());
 

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -934,6 +934,16 @@ function load_plan_map(url, div, plan)
             }
             }).bindPopup(district_popup_content);
 
+
+        function on_mouse_event(evtdata) {
+            const apply_highlight = evtdata.type === 'mouseover';
+            const index = data.features.indexOf(evtdata.layer.feature);
+            const tableRowEl = $('table tbody tr').get(index);
+            tableRowEl.classList.toggle('highlighted', apply_highlight);
+        }
+        geojson.on('mouseover', on_mouse_event);
+        geojson.on('mouseout', on_mouse_event);
+
         console.log('GeoJSON bounds:', geojson.getBounds());
 
         // 

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -933,8 +933,6 @@ function load_plan_map(url, div, plan, table)
                 return { weight: 2, fillOpacity: .5, color: which_district_color(district, plan) };
             }
             }).bindPopup(district_popup_content);
-        window.the_geojson = geojson;
-        window.the_data = data;
 
 
         // On map layer hover: highlight associated table rows 

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -80,6 +80,10 @@
             background-image: url({{ url_for('static', filename='unknown-pattern.png') }});
         }
 
+        table tr.highlighted {
+            background-color: #f5f5f5; /* same as bootstrap's hover row style */
+        }
+
     </style>
 {% endblock %}
 {% block content %}

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -84,6 +84,22 @@
             background-color: #f5f5f5; /* same as bootstrap's hover row style */
         }
 
+        @keyframes highlight-district {
+            from {
+                fill-opacity: 0.5;
+                stroke-width: 2;
+            }
+            to {
+                stroke-width: 7;
+                fill-opacity: 1;
+            }
+        }
+        .highlight {
+            animation: highlight-district 1.3s linear infinite;
+            animation-direction: alternate;
+        }
+        
+
     </style>
 {% endblock %}
 {% block content %}

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -84,19 +84,8 @@
             background-color: #f5f5f5; /* same as bootstrap's hover row style */
         }
 
-        @keyframes highlight-district {
-            from {
-                fill-opacity: 0.5;
-                stroke-width: 2;
-            }
-            to {
-                stroke-width: 7;
-                fill-opacity: 1;
-            }
-        }
-        .highlight {
-            animation: highlight-district 1.3s linear infinite;
-            animation-direction: alternate;
+        path.highlight {
+            stroke-width: 5;
         }
         
 


### PR DESCRIPTION
Really felt like there needed to be a better way to correlate the table rows with the map above. (and vice versa)

I went with styling that felt decent to me (mimic table row hover and strengthen the stroke-width), but I'm totally open to trying other ideas out.

GIF demo:

![Kapture 2021-06-13 at 19 21 27](https://user-images.githubusercontent.com/39191/121831688-ed0d1280-cc7c-11eb-9fb9-b9058e52c3a2.gif)
