### PR TITLE
adopt responsive table styling, courtesy of the jehl-table

### DIFF
--- a/planscore/website/static/plan.css
+++ b/planscore/website/static/plan.css
@@ -42,3 +42,50 @@ div.planscore-partylegend div.planscore-partylegend-words {
     display: inline-block;
     vertical-align: text-bottom;
 }
+
+/* 
+    CSS responsive table with fixed column and row headers and scroll snap
+    by Scott Jehl
+    https://codepen.io/scottjehl/pen/abJrPOP?editors=1100
+*/
+.table-jehl {
+    height: calc(100vh - 400px);
+    min-height: 300px;
+    scroll-snap-type: x mandatory;
+    padding: 0;
+    overflow: auto;
+    width: 100%;
+    border: 1px solid #ddd;
+    margin-bottom: 15px;
+}
+.table-jehl th, .table-jehl td {
+    scroll-snap-align: start;
+}
+.table-jehl thead {
+    z-index: 1000;
+    position: relative;
+}
+.table-jehl thead th {
+    position: sticky;
+    top: 0;
+}
+.table-jehl thead th:first-child {
+    left: 0;
+    z-index: 1001;
+    border-left: 0;
+}
+.table-jehl tbody {
+    z-index: 10;
+    position: relative;
+}
+.table-jehl tbody th {
+    background-clip: padding-box;
+    border-left: 0;
+    position: sticky;
+    left: 0;
+}
+.table-jehl thead th,
+.table-jehl tbody th {
+    background-color: #f8f8f8;
+}
+  

--- a/planscore/website/static/plan.css
+++ b/planscore/website/static/plan.css
@@ -43,20 +43,34 @@ div.planscore-partylegend div.planscore-partylegend-words {
     vertical-align: text-bottom;
 }
 
+.table-districts {
+    height: calc(100vh - 400px - 20px); /* fit on screen along with the 400px tall map, and some margin */
+    min-height: 300px;
+    padding: 0;
+    width: 100%;
+    margin-bottom: 15px;
+}
+@media only print {
+    .table-districts { height: auto; }
+}
+.table-districts td, .table-districts th { text-align: right; }
+.table-districts td.ltxt, .table-districts th.ltxt { text-align: left; }
+.table-districts tbody td {
+    white-space: nowrap; /* nowrap => body rows stay single-line => more dense display */
+}
+.table-districts table {
+    margin: 0;
+}
+
 /* 
     CSS responsive table with fixed column and row headers and scroll snap
     by Scott Jehl
     https://codepen.io/scottjehl/pen/abJrPOP?editors=1100
 */
 .table-jehl {
-    height: calc(100vh - 400px);
-    min-height: 300px;
     scroll-snap-type: x mandatory;
-    padding: 0;
     overflow: auto;
-    width: 100%;
     border: 1px solid #ddd;
-    margin-bottom: 15px;
 }
 .table-jehl th, .table-jehl td {
     scroll-snap-align: start;
@@ -88,4 +102,3 @@ div.planscore-partylegend div.planscore-partylegend-words {
 .table-jehl tbody th {
     background-color: #f8f8f8;
 }
-  

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -868,7 +868,9 @@ function load_plan_score(url, message_section, score_section,
                 } else {
                     value = '???';
                 }
-                tags = tags.concat([`<td ${maybeAlignLeft(j)}>`, value, '</td>']);
+                tags = j == 0 
+                  ? tags.concat([`<th ${maybeAlignLeft(j)}>`, value, '</th>'])
+                  : tags.concat([`<td ${maybeAlignLeft(j)}>`, value, '</td>']);
             }
             tags = tags.concat(['</tr>']);
         }

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -87,11 +87,6 @@
         path.highlight {
             stroke-width: 5;
         }
-        
-
-        .table td, table th { text-align: right; }
-        .table td.ltxt, table th.ltxt { text-align: left; }
-       
     </style>
 {% endblock %}
 {% block content %}
@@ -162,7 +157,7 @@
         </li>
     </ul>
     <p id="map"></p>
-    <div class="col-xs-12 col-sm-12  table-jehl">
+    <div class="col-xs-12 col-sm-12  table-jehl table-districts">
         <table class="table table-hover" id="districts">
             {# this table will be populated by load_plan_score() #}
         </table>

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -162,13 +162,12 @@
         </li>
     </ul>
     <p id="map"></p>
-    <div class="table-responsive col-xs-12 col-sm-12">
+    <div class="col-xs-12 col-sm-12  table-jehl">
         <table class="table table-hover" id="districts">
             {# this table will be populated by load_plan_score() #}
         </table>
-        <br>
-        <a href="#" id="text-link">Download raw data as tab-delimited text</a>.
     </div>
+    <a href="#" id="text-link">Download raw data as tab-delimited text</a>.
     </section>
 	<script language="javascript">
 	    var LEAN_BLUE_PATTERN_URL = "{{ url_for('static', filename='lean-blue-pattern.png') }}",


### PR DESCRIPTION
fixes #361 

I also chose to set a height on the table, allowing you to browse the full table while the map remains on screen. 

I dropped bootstrap's table-responsive as it conflicts (and also has other opinions on text-wrapping).

After interacting with the page/table/map a bit I'm pretty pleased with the feel. Open to suggestions/tweaks of course.

### before and after on desktop: 
![image](https://user-images.githubusercontent.com/39191/123525848-a827a980-d688-11eb-948f-57f61e395dc6.png)

### before and after on mobile:
![image](https://user-images.githubusercontent.com/39191/123526155-c8f0fe80-d68a-11eb-93ba-595beb42451d.png)

