### PR TITLE
perf: preload the geometry

### DIFF
--- a/planscore/website/__init__.py
+++ b/planscore/website/__init__.py
@@ -1,6 +1,5 @@
 import flask, os, urllib.parse, markdown, hashlib
 from .. import data, constants
-from flask import request
 
 MODELS_BASEDIR = os.path.join(os.path.dirname(__file__), 'models')
 
@@ -26,11 +25,6 @@ def digested_static_url(filename):
         sha1 = hashlib.sha1()
         sha1.update(file.read())
     return flask.url_for('get_digested_file', digest=sha1.hexdigest()[:7], filename=filename)
-
-@app.template_global()
-def cool_plan_id():
-    plan_id = list(request.args.keys())[0]
-    return plan_id
 
 @app.route('/resource-<digest>/<path:filename>')
 def get_digested_file(digest, filename):

--- a/planscore/website/__init__.py
+++ b/planscore/website/__init__.py
@@ -1,5 +1,6 @@
 import flask, os, urllib.parse, markdown, hashlib
 from .. import data, constants
+from flask import request
 
 MODELS_BASEDIR = os.path.join(os.path.dirname(__file__), 'models')
 
@@ -25,6 +26,11 @@ def digested_static_url(filename):
         sha1 = hashlib.sha1()
         sha1.update(file.read())
     return flask.url_for('get_digested_file', digest=sha1.hexdigest()[:7], filename=filename)
+
+@app.template_global()
+def cool_plan_id():
+    plan_id = list(request.args.keys())[0]
+    return plan_id
 
 @app.route('/resource-<digest>/<path:filename>')
 def get_digested_file(digest, filename):

--- a/planscore/website/__init__.py
+++ b/planscore/website/__init__.py
@@ -20,17 +20,18 @@ def get_function_url(relpath):
     planscore_api_base = flask.current_app.config['PLANSCORE_API_BASE']
     return urllib.parse.urljoin(planscore_api_base, relpath)
 
+def get_plan_id():
+    args = list(request.args.keys())
+    if len(args):
+        plan_id = args[0]
+        return plan_id
+
 @app.template_global()
 def digested_static_url(filename):
     with open(os.path.join(flask.current_app.static_folder, filename), 'rb') as file:
         sha1 = hashlib.sha1()
         sha1.update(file.read())
     return flask.url_for('get_digested_file', digest=sha1.hexdigest()[:7], filename=filename)
-
-@app.template_global()
-def cool_plan_id():
-    plan_id = list(request.args.keys())[0]
-    return plan_id
 
 @app.route('/resource-<digest>/<path:filename>')
 def get_digested_file(digest, filename):
@@ -63,9 +64,12 @@ def get_plan():
     data_url_pattern = get_data_url_pattern(flask.current_app.config['PLANSCORE_S3_BUCKET'])
     geom_url_prefix = constants.S3_URL_PATTERN.format(k='', b=flask.current_app.config['PLANSCORE_S3_BUCKET'])
     text_url_pattern = get_text_url_pattern(flask.current_app.config['PLANSCORE_S3_BUCKET'])
+    geom_url_suffix=data.UPLOAD_GEOMETRY_KEY.format(id=get_plan_id())
+    index_url=data_url_pattern.format(id=get_plan_id())
     return flask.render_template('plan.html',
         data_url_pattern=data_url_pattern, geom_url_prefix=geom_url_prefix,
-        text_url_pattern=text_url_pattern)
+        text_url_pattern=text_url_pattern, geom_url_suffix=geom_url_suffix,
+        index_url=index_url)
 
 @app.route('/webinar/')
 def get_webinar_mar23():

--- a/planscore/website/__init__.py
+++ b/planscore/website/__init__.py
@@ -1,6 +1,5 @@
 import flask, os, urllib.parse, markdown, hashlib
 from .. import data, constants
-from flask import request
 
 MODELS_BASEDIR = os.path.join(os.path.dirname(__file__), 'models')
 
@@ -19,12 +18,6 @@ def get_text_url_pattern(bucket):
 def get_function_url(relpath):
     planscore_api_base = flask.current_app.config['PLANSCORE_API_BASE']
     return urllib.parse.urljoin(planscore_api_base, relpath)
-
-def get_plan_id():
-    args = list(request.args.keys())
-    if len(args):
-        plan_id = args[0]
-        return plan_id
 
 @app.template_global()
 def digested_static_url(filename):
@@ -64,12 +57,10 @@ def get_plan():
     data_url_pattern = get_data_url_pattern(flask.current_app.config['PLANSCORE_S3_BUCKET'])
     geom_url_prefix = constants.S3_URL_PATTERN.format(k='', b=flask.current_app.config['PLANSCORE_S3_BUCKET'])
     text_url_pattern = get_text_url_pattern(flask.current_app.config['PLANSCORE_S3_BUCKET'])
-    geom_url_suffix=data.UPLOAD_GEOMETRY_KEY.format(id=get_plan_id())
-    index_url=data_url_pattern.format(id=get_plan_id())
+    geom_url_suffix_key=data.UPLOAD_GEOMETRY_KEY
     return flask.render_template('plan.html',
         data_url_pattern=data_url_pattern, geom_url_prefix=geom_url_prefix,
-        text_url_pattern=text_url_pattern, geom_url_suffix=geom_url_suffix,
-        index_url=index_url)
+        text_url_pattern=text_url_pattern, geom_url_suffix_key=geom_url_suffix_key)
 
 @app.route('/webinar/')
 def get_webinar_mar23():

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -6,7 +6,9 @@
     <link rel="stylesheet" href="{{ digested_static_url('plan.css') }}" />
     <script src="{{ digested_static_url('plan.js') }}"></script>
 
-    <link rel=preloadz as=fetch href="{{ data_url_pattern }} ${{cool_plan_id()}}">
+    <!-- Preload the data we'll use -->
+    <link rel=preload as=fetch crossorigin href="{{ index_url }}">
+    <link rel=preload as=fetch crossorigin href="{{ geom_url_prefix }}{{ geom_url_suffix }}">
 
     <!-- Highcharts does charts and also maps -->
     <script src="https://code.highcharts.com/highcharts.js"></script>
@@ -92,9 +94,6 @@
     </style>
 {% endblock %}
 {% block content %}
-    <h1>
-        hello {{ cool_plan_id() }}
-    </h1>
     <section id="message">
         Loading plan…
     </section>
@@ -184,15 +183,6 @@
 	        pb_metric_url = 'https://planscore.org/metrics/partisanbias/',
 	        mm_metric_url = 'https://planscore.org/metrics/meanmedian/',
 	        model_url_pattern = '{{ url_for("get_model_description", prefix="data/2020") }}';
-
-        // preload the geometry as it can take a while to load
-        const probably_geometry_url = plan_url.replace('index.json', 'geometry.json');
-        const link_el = document.createElement('link');
-        link_el.rel = 'preload';
-        link_el.as = 'fetch';
-        link_el.href = probably_geometry_url;
-        link_el.crossOrigin = 'anonymous';
-        document.head.append(link_el);
 
 	    load_plan_score(plan_url,
 	        document.getElementById('message'),

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -185,6 +185,15 @@
 	        mm_metric_url = 'https://planscore.org/metrics/meanmedian/',
 	        model_url_pattern = '{{ url_for("get_model_description", prefix="data/2020") }}';
 
+        // preload the geometry as it can take a while to load
+        const probably_geometry_url = plan_url.replace('index.json', 'geometry.json');
+        const link_el = document.createElement('link');
+        link_el.rel = 'preload';
+        link_el.as = 'fetch';
+        link_el.href = probably_geometry_url;
+        link_el.crossOrigin = 'anonymous';
+        document.head.append(link_el);
+
 	    load_plan_score(plan_url,
 	        document.getElementById('message'),
 	        document.getElementById('plan-score'),

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -6,6 +6,8 @@
     <link rel="stylesheet" href="{{ digested_static_url('plan.css') }}" />
     <script src="{{ digested_static_url('plan.js') }}"></script>
 
+    <link rel=preloadz as=fetch href="{{ data_url_pattern }} ${{cool_plan_id()}}">
+
     <!-- Highcharts does charts and also maps -->
     <script src="https://code.highcharts.com/highcharts.js"></script>
 
@@ -90,6 +92,9 @@
     </style>
 {% endblock %}
 {% block content %}
+    <h1>
+        hello {{ cool_plan_id() }}
+    </h1>
     <section id="message">
         Loading plan…
     </section>

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -6,8 +6,6 @@
     <link rel="stylesheet" href="{{ digested_static_url('plan.css') }}" />
     <script src="{{ digested_static_url('plan.js') }}"></script>
 
-    <link rel=preloadz as=fetch href="{{ data_url_pattern }} ${{cool_plan_id()}}">
-
     <!-- Highcharts does charts and also maps -->
     <script src="https://code.highcharts.com/highcharts.js"></script>
 
@@ -92,9 +90,6 @@
     </style>
 {% endblock %}
 {% block content %}
-    <h1>
-        hello {{ cool_plan_id() }}
-    </h1>
     <section id="message">
         Loading plan…
     </section>

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -6,10 +6,6 @@
     <link rel="stylesheet" href="{{ digested_static_url('plan.css') }}" />
     <script src="{{ digested_static_url('plan.js') }}"></script>
 
-    <!-- Preload the data we'll use -->
-    <link rel=preload as=fetch crossorigin href="{{ index_url }}">
-    <link rel=preload as=fetch crossorigin href="{{ geom_url_prefix }}{{ geom_url_suffix }}">
-
     <!-- Highcharts does charts and also maps -->
     <script src="https://code.highcharts.com/highcharts.js"></script>
 
@@ -183,6 +179,19 @@
 	        pb_metric_url = 'https://planscore.org/metrics/partisanbias/',
 	        mm_metric_url = 'https://planscore.org/metrics/meanmedian/',
 	        model_url_pattern = '{{ url_for("get_model_description", prefix="data/2020") }}';
+
+
+        // Preload the data we'll use
+        const index_url = format_url('{{ data_url_pattern }}', plan_id);
+        const geometry_url = format_url('{{ geom_url_prefix }}{{ geom_url_suffix_key }}', plan_id);
+        for (const preload_url of [index_url, geometry_url]) {
+            const link_el = document.createElement('link');
+            link_el.rel = 'preload';
+            link_el.as = 'fetch';
+            link_el.crossOrigin = 'anonymous';
+            link_el.href = preload_url;
+            document.head.append(link_el);
+        }
 
 	    load_plan_score(plan_url,
 	        document.getElementById('message'),


### PR DESCRIPTION

Current loading waterfall:
![image](https://user-images.githubusercontent.com/39191/124340780-7624b480-db6c-11eb-947d-8d957e7ab944.png)

The network request for the geometry data only starts once the plan json is done (red annotation). The pink annotation shows the 300ms-ish of opportunity.

If we start a preload for the geometry at the same time as we start the plan json, we save some time.
![image](https://user-images.githubusercontent.com/39191/124340879-33afa780-db6d-11eb-8e81-f78c2e0f4edd.png)

