### PR TITLE
annotate: add polling

### DIFF
--- a/data/sample-NC2019/index-preread-start.json
+++ b/data/sample-NC2019/index-preread-start.json
@@ -3,7 +3,7 @@
   "districts": [],
   "id": "20191229T184708.315233888Z",
   "key": "uploads/20191229T184708.315233888Z/upload/geometry.json",
-  "message": "Reading this newly-uploaded plan. Reload this page to see the result.",
+  "message": "Parsing this newly-uploaded plan.",
   "model": null,
   "progress": null,
   "start_time": 1577558850,

--- a/planscore/preread.py
+++ b/planscore/preread.py
@@ -12,7 +12,7 @@ def create_upload(s3, bucket, key, id):
     '''
     '''
     upload = data.Upload(id, key, [],
-        message='Reading this newly-uploaded plan. Reload this page to see the result.',
+        message='Parsing this newly-uploaded plan.',
         )
     observe.put_upload_index(data.Storage(s3, bucket, None), upload)
     return upload

--- a/planscore/website/static/annotate-new.js
+++ b/planscore/website/static/annotate-new.js
@@ -14,15 +14,17 @@ function getUrlParameter(name, search)
 
 function show_message(text, preread_section, message_section)
 {
-    // TODO: keep old msgs…
-    while(message_section.firstChild)
-    {
-        message_section.removeChild(message_section.firstChild);
+    // If showing the same message, just append an ellipsis.
+    const match_el = Array.from(message_section.querySelectorAll('p'))
+        .find(el => el.textContent.startsWith(text));
+    
+    if (match_el) {
+        match_el.textContent += '…';
+    } else {
+        const el = document.createElement('p');
+        el.textContent = text;
+        message_section.append(el);
     }
-
-    const el = document.createElement('p');
-    el.textContent = text;
-    message_section.append(el);
 
     preread_section.style.display = 'none';
     message_section.style.display = 'block';
@@ -115,7 +117,7 @@ function start_plan_preread_polling(url, message_section, preread_section, descr
         }, 3000);
     };
 
-    show_message('Loading district plan…', preread_section, message_section);
+    show_message('Loading district plan', preread_section, message_section);
     make_xhr();
 }
 

--- a/planscore/website/templates/annotate.html
+++ b/planscore/website/templates/annotate.html
@@ -112,7 +112,7 @@
         form.elements['bucket'].value = s3_bucket;
         form.elements['key'].value = s3_key;
 
-	    load_plan_preread(plan_url,
+	    start_plan_preread_polling(plan_url,
 	        document.getElementById('message'),
 	        document.getElementById('plan-preread'),
 	        document.getElementById('plan-description'),

--- a/planscore/website/templates/annotate.html
+++ b/planscore/website/templates/annotate.html
@@ -29,7 +29,7 @@
 {% endblock %}
 {% block content %}
     <section id="message">
-        Loading plan…
+        <p>Loading district plan</p>
     </section>
     <section id="plan-preread">
 


### PR DESCRIPTION
the page just polls for updates now. no more asking the user to refresh. (ref #365) 


I went for something pretty lo-fi. If the 'message' from the backend is the same, I just append some ellipsis. 
Especially since the text is center-aligned, it's fairly visible.

I'm happy to upgrade this to something more obvious if you want, but it seemed like a nice, minimal start. ;)

![image](https://user-images.githubusercontent.com/39191/124369324-8053bb00-dc1f-11eb-8e1f-52b05cff4eb4.png)
