### PR TITLE
add extra grace time on upload form interaction

### DIFF
--- a/planscore/website/static/upload.js
+++ b/planscore/website/static/upload.js
@@ -1,4 +1,4 @@
-function enable_form(url, form)
+function fetch_upload_tokens(url, form, res, rej)
 {
     var request = new XMLHttpRequest();
     request.open('GET', url, true);
@@ -16,12 +16,14 @@ function enable_form(url, form)
                 form.elements[key].value = upload_fields[key];
             }
             form.action = form_action_url;
-            form.dataset.configured = "true"
+            // res()
+            setTimeout(_ => res(), 10000);
         }
     };
 
     request.onerror = function(e) { 
         console.error('There was a connection error', e);
+        rej();
     };
     request.send();
 }

--- a/planscore/website/static/upload.js
+++ b/planscore/website/static/upload.js
@@ -1,29 +1,14 @@
-function fetch_upload_tokens(url, form, res, rej)
+function fetch_upload_tokens(url, form, signal) 
 {
-    var request = new XMLHttpRequest();
-    request.open('GET', url, true);
+    return fetch(url, {signal}).then(r => r.json()).then(data => {
+        // Returns a two-element array with URL and form fields.
+        const form_action_url = data[0];
+        const upload_fields = data[1];
 
-    request.onload = function()
-    {
-        if(request.status >= 200 && request.status < 400)
-        {
-            // Returns a two-element array with URL and form fields.
-            var data = JSON.parse(request.responseText);
-            const form_action_url = data[0];
-            const upload_fields = data[1];
-
-            for(var key in upload_fields) {
-                form.elements[key].value = upload_fields[key];
-            }
-            form.action = form_action_url;
-            // res()
-            setTimeout(_ => res(), 10000);
+        for(var key in upload_fields) {
+            form.elements[key].value = upload_fields[key];
         }
-    };
-
-    request.onerror = function(e) { 
-        console.error('There was a connection error', e);
-        rej();
-    };
-    request.send();
+        form.action = form_action_url;
+        console.log('Upload tokens populated.');
+    });
 }

--- a/planscore/website/templates/upload.html
+++ b/planscore/website/templates/upload.html
@@ -146,61 +146,48 @@
 	    var upload_form = document.getElementById('upload'),
 	        file_input = document.getElementById('file'),
 	        file_label = file_input.nextElementSibling,
-            file_label_text = file_label.textContent;
+            select_a_file_text = file_label.textContent;
 
-        // Basic pattern from https://medium.com/@bramus/cancel-a-javascript-promise-with-abortcontroller-3540cbbda0a9
-        function abortable_timeout(duration, signal) {
-            if (signal.aborted) {
-                return Promise.reject(new Error('Aborted'));
-            }
-            return new Promise((resolve, reject) => {
-                const handle = setTimeout(resolve, duration);
-                signal.addEventListener('abort', e => {
-                    clearTimeout(handle);
-                    reject(new Error('aborted'));
-                });
-            });
-        }
 
-        
-        const fetch_tokens_promise = new Promise((res, rej) => {
-            fetch_upload_tokens('https://api.planscore.org/{{upload_fields_url}}', upload_form, res, rej);
-        });
-        // Once we have upload tokens, we can cancel the extra_wait
+        // Use an AbortController to make an abortable fetch that can give up if its not done in time. https://github.com/PlanScore/PlanScore/pull/379
         const controller = new AbortController();
-        fetch_tokens_promise.then(() => {
-            controller.abort();
-            console.log('Upload tokens fetched.');
+
+        // For local dev, prefix the upload_fields_url with https://api.planscore.org/
+        const fetch_tokens_promise = fetch_upload_tokens('{{upload_fields_url}}', upload_form, controller.signal);
+
+        fetch_tokens_promise.catch(err => 
+        {
+            file_label.textContent = 'API Server connection failure!';
+            if (err.name === 'AbortError') {
+                alert(`Didn't connect to PlanScore API server in time. Reload and try again?`);
+            } else {
+                console.error('Fetch failure', err);
+            }
         });
 
 	    file_input.addEventListener('change', function(e)
 	    {
             if(!this.files.length) {
-                file_label.textContent = file_label_text;
+                file_label.textContent = select_a_file_text;
                 return;
             }
-            
+
             console.log('File selected');
             file_label.textContent = `Awaiting server connection…`;
-            
-            // After file selection, give 5 more seconds grace time for fetch_tokens before showing user an error.
-            const extra_wait_for_enable_form = abortable_timeout(10 * 1000, controller.signal);
-            extra_wait_for_enable_form.then(() => {
-                console.warn('It\;s now 5s after file selection and the upload tokens arent available yet');
-                alert(`Didn't connect to PlanScore API server. Reload and try again?`);
-            }).catch(e => console.log('extra wait time cancelled'));
 
+            // After file selection, give 7 more seconds grace time for fetch_tokens before giving up
+            setTimeout(() => {
+                controller.abort();
+            }, 7 * 1000);
 
             fetch_tokens_promise.then(() => {
                 console.log('File selected AND upload tokens fetched. Starting submit');
                 file_label.textContent = `Uploading ${this.files[0].name} …`;
-                // upload_form.submit();
+                upload_form.submit();
             });
 	    });
-
 	</script>
 
 	{% include 'olark-embed.html' %}
 
 {% endblock %}
-

--- a/planscore/website/templates/upload.html
+++ b/planscore/website/templates/upload.html
@@ -108,7 +108,7 @@
         </div>
         <div class="col-md-6">
             <!-- action is set in upload.js -->
-            <form id="upload" action="#" method="post" enctype="multipart/form-data" data-configured="false">
+            <form id="upload" action="#" method="post" enctype="multipart/form-data">
                 <input type="hidden" name="key">
                 <input type="hidden" name="AWSAccessKeyId">
                 <input type="hidden" name="policy">
@@ -147,28 +147,60 @@
 	        file_input = document.getElementById('file'),
 	        file_label = file_input.nextElementSibling,
             file_label_text = file_label.textContent;
-	    
-	    enable_form('{{upload_fields_url}}', upload_form);
-	    
+
+        // Basic pattern from https://medium.com/@bramus/cancel-a-javascript-promise-with-abortcontroller-3540cbbda0a9
+        function abortable_timeout(duration, signal) {
+            if (signal.aborted) {
+                return Promise.reject(new Error('Aborted'));
+            }
+            return new Promise((resolve, reject) => {
+                const handle = setTimeout(resolve, duration);
+                signal.addEventListener('abort', e => {
+                    clearTimeout(handle);
+                    reject(new Error('aborted'));
+                });
+            });
+        }
+
+        
+        const fetch_tokens_promise = new Promise((res, rej) => {
+            fetch_upload_tokens('https://api.planscore.org/{{upload_fields_url}}', upload_form, res, rej);
+        });
+        // Once we have upload tokens, we can cancel the extra_wait
+        const controller = new AbortController();
+        fetch_tokens_promise.then(() => {
+            controller.abort();
+            console.log('Upload tokens fetched.');
+        });
 
 	    file_input.addEventListener('change', function(e)
 	    {
-            // Checking if enable_form()'s XHR is not done yet. (Very unlikely)
-            if (upload_form.dataset.configured != 'true') {
-                alert(`Didn't connect to PlanScore API server. Try again?`);
-                this.value = ''; // Clear file input to allow user to re-select
+            if(!this.files.length) {
+                file_label.textContent = file_label_text;
+                return;
             }
+            
+            console.log('File selected');
+            file_label.textContent = `Awaiting server connection…`;
+            
+            // After file selection, give 5 more seconds grace time for fetch_tokens before showing user an error.
+            const extra_wait_for_enable_form = abortable_timeout(10 * 1000, controller.signal);
+            extra_wait_for_enable_form.then(() => {
+                console.warn('It\;s now 5s after file selection and the upload tokens arent available yet');
+                alert(`Didn't connect to PlanScore API server. Reload and try again?`);
+            }).catch(e => console.log('extra wait time cancelled'));
 
-            if(this.files.length) {
-	            file_label.textContent = `Uploading ${this.files[0].name} …`;
-                upload_form.submit();
-	        } else {
-	            file_label.textContent = file_label_text;
-	        }
+
+            fetch_tokens_promise.then(() => {
+                console.log('File selected AND upload tokens fetched. Starting submit');
+                file_label.textContent = `Uploading ${this.files[0].name} …`;
+                // upload_form.submit();
+            });
 	    });
-	    
+
 	</script>
 
 	{% include 'olark-embed.html' %}
 
 {% endblock %}
+


### PR DESCRIPTION
(followup to #376)

from https://github.com/PlanScore/PlanScore/issues/365#issuecomment-873624408

> After merging #376 I occasionally see the error message “Didn't connect to PlanScore API server.” I think this might be confusing for a user though I like the one-button improvement we’ve got now. How can we accommodate a slow server response so a user gets a more helpful message?

As I mentioned, this issue is due to a race of the /upload GET against the file selection.

In this PR, I add an extra 7 seconds of grace time after file-selection before the user sees an error.

impl-wise: there were a few ways to do this, but switching the XHR to fetch had a few benefits:

* in my local dev the /upload endpoint was 404ing, but oddly that didn't even hit the `request.onerror` callback. (tbh, i forget why.. been too long since i've worked with the actual XHR api). But yeah moving to fetch means better error handling by default.
* the fetch() is aborted if it hasn't finished 7s after the user picks a file.  That feels like a nice balance.
* fetch has built-in support for abortcontroller, which is the "new" fancy way of cancelling promises. https://developers.google.com/web/updates/2017/09/abortable-fetch

