### PR TITLE
Do not pre-fetch index JSON

### DIFF
--- a/planscore/observe.py
+++ b/planscore/observe.py
@@ -17,23 +17,26 @@ def get_upload_index(storage, key):
 def put_upload_index(storage, upload):
     ''' Save a JSON index, a plaintext file, and a log entry for this upload.
     '''
+    print('put_upload_index: {}'.format(upload.message))
+    cache_control = 'public, no-cache, no-store'
+
     key1 = upload.index_key()
     body1 = upload.to_json().encode('utf8')
 
     storage.s3.put_object(Bucket=storage.bucket, Key=key1, Body=body1,
-        ContentType='text/json', ACL='public-read')
+        ContentType='text/json', ACL='public-read', CacheControl=cache_control)
 
     key2 = upload.plaintext_key()
     body2 = upload.to_plaintext().encode('utf8')
 
     storage.s3.put_object(Bucket=storage.bucket, Key=key2, Body=body2,
-        ContentType='text/plain', ACL='public-read')
+        ContentType='text/plain', ACL='public-read', CacheControl=cache_control)
 
     key3 = upload.logentry_key(str(uuid.uuid4()))
     body3 = upload.to_logentry().encode('utf8')
 
     storage.s3.put_object(Bucket=storage.bucket, Key=key3, Body=body3,
-        ContentType='text/plain', ACL='public-read')
+        ContentType='text/plain', ACL='public-read', CacheControl=cache_control)
 
 def get_expected_tile(enqueued_key, upload):
     ''' Return an expect tile key for an enqueued one.

--- a/planscore/tests/test_observe.py
+++ b/planscore/tests/test_observe.py
@@ -46,16 +46,19 @@ class TestObserveTiles (unittest.TestCase):
         self.assertEqual(put_call1[2], dict(Bucket=storage.bucket,
             Key=upload.index_key.return_value,
             Body=upload.to_json.return_value.encode.return_value,
+            CacheControl='public, no-cache, no-store',
             ACL='public-read', ContentType='text/json'))
         
         self.assertEqual(put_call2[2], dict(Bucket=storage.bucket,
             Key=upload.plaintext_key.return_value,
             Body=upload.to_plaintext.return_value.encode.return_value,
+            CacheControl='public, no-cache, no-store',
             ACL='public-read', ContentType='text/plain'))
         
         self.assertEqual(put_call3[2], dict(Bucket=storage.bucket,
             Key=upload.logentry_key.return_value,
             Body=upload.to_logentry.return_value.encode.return_value,
+            CacheControl='public, no-cache, no-store',
             ACL='public-read', ContentType='text/plain'))
 
     def test_put_part_timings(self):

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -184,7 +184,7 @@
         // Preload the data we'll use
         const index_url = format_url('{{ data_url_pattern }}', plan_id);
         const geometry_url = format_url('{{ geom_url_prefix }}{{ geom_url_suffix_key }}', plan_id);
-        for (const preload_url of [index_url, geometry_url]) {
+        for (const preload_url of [geometry_url]) {
             const link_el = document.createElement('link');
             link_el.rel = 'preload';
             link_el.as = 'fetch';


### PR DESCRIPTION
Followup to #375: index JSON was getting stuck in cache when pre-fetched despite presence of cache-control directives. Remove it for now, maybe revisit in #378?