### PR TITLE
Fix hang when an empty district is provided

### DIFF
--- a/planscore/observe.py
+++ b/planscore/observe.py
@@ -227,6 +227,11 @@ def accumulate_district_subtotals(part_subtotals, upload):
     '''
     districts = []
     
+    print('accumulate_district_subtotals part_subtotals:')
+    print(json.dumps(part_subtotals))
+    print('accumulate_district_subtotals upload:')
+    print(upload.to_json())
+    
     # copy districts from the upload
     for upload_district in upload.districts:
         # use a defaultdict to accept new values
@@ -337,4 +342,4 @@ def lambda_handler(event, context):
 
     put_upload_index(storage, complete_upload)
     put_part_timings(storage, upload2, subtotals, part_type)
-    clean_up_leftover_parts(storage, expected_parts)
+    #clean_up_leftover_parts(storage, expected_parts)

--- a/planscore/observe.py
+++ b/planscore/observe.py
@@ -227,11 +227,6 @@ def accumulate_district_subtotals(part_subtotals, upload):
     '''
     districts = []
     
-    print('accumulate_district_subtotals part_subtotals:')
-    print(json.dumps(part_subtotals))
-    print('accumulate_district_subtotals upload:')
-    print(upload.to_json())
-    
     # Empty dict to use as a template for new totals
     empty_totals_dict = {
         subtotal_key: 0. for subtotal_key in
@@ -348,4 +343,4 @@ def lambda_handler(event, context):
 
     put_upload_index(storage, complete_upload)
     put_part_timings(storage, upload2, subtotals, part_type)
-    #clean_up_leftover_parts(storage, expected_parts)
+    clean_up_leftover_parts(storage, expected_parts)

--- a/planscore/tests/test_observe.py
+++ b/planscore/tests/test_observe.py
@@ -280,6 +280,64 @@ class TestObserveTiles (unittest.TestCase):
         self.assertEqual(districts3[1]['totals']['X'], 2)
         self.assertEqual(districts3[0]['totals']['Voters'], 567.09)
         self.assertEqual(districts3[1]['totals']['Voters'], 932.89)
+    
+    def test_accumulate_district_subtotals_empties(self):
+        '''
+        '''
+        upload = unittest.mock.Mock()
+        upload.id = 'sample-plan'
+        
+        inputs = [
+            observe.SubTotal({
+                "uploads/sample-plan/geometries/0.wkt": {},
+                "uploads/sample-plan/geometries/1.wkt": {
+                    "Population 2010": 18,
+                    "US President 2016 - DEM": 100,
+                    "US President 2016 - REP": 200
+                },
+            }, {
+                "start_time": 1630364292.031,
+                "elapsed_time": 0.232,
+                "features": 3
+            }),
+            observe.SubTotal({
+                "uploads/sample-plan/geometries/0.wkt": {},
+            }, {
+                "start_time": 1630364291.918,
+                "elapsed_time": 0.271,
+                "features": 3
+            }),
+            observe.SubTotal({
+                "uploads/sample-plan/geometries/0.wkt": {},
+                "uploads/sample-plan/geometries/1.wkt": {
+                    "Population 2010": 4,
+                    "US President 2016 - DEM": 0,
+                    "US President 2016 - REP": 100
+                },
+            }, {
+                "start_time": 1630364291.997,
+                "elapsed_time": 0.259,
+                "features": 1
+            }),
+        ]
+
+        
+        upload.districts = [None, None]
+        districts = observe.accumulate_district_subtotals(inputs, upload)
+        
+        self.assertEqual(len(districts), 2)
+        self.assertIn('Population 2010', districts[0]['totals'])
+        self.assertIn('Population 2010', districts[1]['totals'])
+        self.assertIn('US President 2016 - DEM', districts[0]['totals'])
+        self.assertIn('US President 2016 - REP', districts[0]['totals'])
+        self.assertIn('US President 2016 - DEM', districts[1]['totals'])
+        self.assertIn('US President 2016 - REP', districts[1]['totals'])
+        self.assertEqual(districts[0]['totals']['Population 2010'], 0)
+        self.assertEqual(districts[1]['totals']['Population 2010'], 22)
+        self.assertEqual(districts[0]['totals']['US President 2016 - DEM'], 0)
+        self.assertEqual(districts[0]['totals']['US President 2016 - REP'], 0)
+        self.assertEqual(districts[1]['totals']['US President 2016 - DEM'], 100)
+        self.assertEqual(districts[1]['totals']['US President 2016 - REP'], 300)
 
     def test_adjust_household_income(self):
         '''

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -1061,7 +1061,7 @@ function load_plan_score(url, message_section, score_section,
 
     function on_loaded_score(plan, modified_at)
     {
-        const is_plan_still_parsing = which_score_summary_name(plan) === null;
+        const is_plan_still_parsing = (plan.status !== true && which_score_summary_name(plan) === null);
         if(is_plan_still_parsing) {
             if (plan.message) {
                 // Still processing


### PR DESCRIPTION
Saw an input file with an empty district. Although scores might be weird, these should still complete and correctly report zero population and vote counts.