### PR TITLE
Tweaked plan summary and resource link display

### DIFF
--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -53,12 +53,6 @@ const fieldSubstringToDisplayStr = {
     'Population': 'Pop.',
 };
 
-const houseNames = {
-    'ushouse': 'U.S. House',
-    'statesenate': 'State Senate',
-    'statehouse': 'State House'
-};
-
 const months = [
   'Jan. ',
   'Feb. ',
@@ -978,7 +972,7 @@ function nice_plan_voteshare(plan)
         + 'and ' + nice_percent(red_votes / (blue_votes + red_votes)) + ' (Republican)');
 }
 
-function get_plan_type_text(plan)
+function get_state_full_name(postal_code)
 {
     var states = {
         'XX': 'Null Island',
@@ -999,16 +993,20 @@ function get_plan_type_text(plan)
         'MN': 'Minnesota', 'WV': 'West Virginia', 'MS': 'Mississippi',
         'WI': 'Wisconsin', 'MO': 'Missouri', 'WY': 'Wyoming',
         'MT': 'Montana'
-        };
+    };
+    
+    return states[postal_code];
+}
 
-    var plan_type_text = ['Plan uploaded'];
-
-    if(plan['model'])
-    {
-        plan_type_text = `${states[plan.model.state]} ${houseNames[plan.model.house]} plan`;
-    }
-
-    return plan_type_text;
+function get_house_full_name(house_code)
+{
+    var houseNames = {
+        'ushouse': 'U.S. House',
+        'statesenate': 'State Senate',
+        'statehouse': 'State House'
+    };
+    
+    return houseNames[house_code];
 }
 
 function get_plan_headings(plan, modified_at)
@@ -1035,7 +1033,6 @@ function get_plan_headings(plan, modified_at)
     return {
         description,
         uploaded,
-        plan_type: get_plan_type_text(plan),
         date_only
     };
 }
@@ -1099,9 +1096,9 @@ function load_plan_score(url, message_section, score_section,
         // Clear out and repopulate plan description, upload date, plan type
         clear_element(description_el);
         const headings = get_plan_headings(plan, modified_at);
-        if (headings.plan_type) {
+        if (headings.description) {
             const desc_el = document.createElement('h1');
-            desc_el.textContent = headings.plan_type;
+            desc_el.textContent = plan.description;
             description_el.append(desc_el);
         }
 
@@ -1113,10 +1110,10 @@ function load_plan_score(url, message_section, score_section,
         info_el.classList.add('info');
 
         //needs just the state name without the branch
-        info_el.append(create_info_box('State', '%state_name'));
+        info_el.append(create_info_box('State', get_state_full_name(plan.model.state)));
 
         // needs just the legislative branch
-        info_el.append(create_info_box('Legislative', '%plan_type'));
+        info_el.append(create_info_box('Legislative', get_house_full_name(plan.model.house)));
 
         info_el.append(create_info_box('Added to PlanScore', headings.date_only));
 

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -142,23 +142,23 @@
             plan metrics are featured in our
             <a href="{{planscore_website_base}}/about/historical-data/">historical dataset</a>.
     </small></p>
-    </section>
+
     <section>
       <h2>Explore plan resources.</h2>
       <hr class="no-margin-bottom"/>
 
       <div class="link-grid">
         <a href="#">Authoritative Link <!-- needs %authlink -->
-          <img width=20 height=20 src="/images/external-link.svg" alt="authoritative link for this plan"/>
+          <img width=20 height=20 src="{{planscore_website_base}}/images/external-link.svg" alt="authoritative link for this plan"/>
         </a>
         <a href="#">Preceding Enacted Plan <!-- needs %precedinglink -->
-          <img  width=20 height=20 src="/images/arrow-right.svg" alt="link to the preceding enacted plan" />
+          <img  width=20 height=20 src="{{planscore_website_base}}/images/arrow-right.svg" alt="link to the preceding enacted plan" />
         </a>
         <a href="#">Shapefile <!-- needs %shapelink  -->
-          <img width=20 height=20 src="/images/download.svg" alt="link to a shape file download"/>
+          <img width=20 height=20 src="{{planscore_website_base}}/images/download.svg" alt="link to a shape file download"/>
         </a>
         <a href="#">preview.geojson <!-- needs %geosonlink -->
-          <img  width=20 height=20 src="/images/download.svg" alt="link to a geojson download"/>
+          <img  width=20 height=20 src="{{planscore_website_base}}/images/download.svg" alt="link to a geojson download"/>
         </a>
       </div>
     </section>
@@ -174,6 +174,8 @@
       </div>
     </section>
     <!-- end notes section -->
+
+    </section>
 
     <nav class="content-footer">
       <a class="btn btn-primary" href="/library">Back to Plan Library</a>

--- a/tests.js
+++ b/tests.js
@@ -159,7 +159,6 @@ assert.deepEqual(plan_array4[13],
 assert.deepEqual(plan.get_plan_headings(NC_multisim_index, new Date(2018, 0, 14)), {
     description: false,
     uploaded: 'Uploaded: 1/14/2018',
-    plan_type: [ 'Plan uploaded' ],
     date_only: 'Jan. 14, 2018'
 });
 
@@ -171,7 +170,6 @@ assert.equal(plan_array5.length, 14, 'Should have a header with 13 districts');
 assert.deepEqual(plan.get_plan_headings(NC_public_index), {
     description: 'Here is a great plan.',
     uploaded: 'Uploaded: 1/14/2018',
-    plan_type: 'North Carolina U.S. House plan',
     date_only: 'Jan. 14, 2018'
 }, 'Should determine the right heading text');
 
@@ -194,7 +192,6 @@ assert.deepEqual(plan_array5[13],
 assert.deepEqual(plan.get_plan_headings(NC_public_index, undefined), {
     description: 'Here is a great plan.',
     uploaded: 'Uploaded: 1/14/2018',
-    plan_type: 'North Carolina U.S. House plan',
     date_only: 'Jan. 14, 2018'
 }, 'Should determine the right heading text');
 
@@ -263,7 +260,6 @@ delete headings8.uploaded; // CI env won't have a matching TZ
 delete headings8.date_only;
 assert.deepEqual(headings8, {
     description: 'geometry.json (v8, with corrected incumbents)',
-    plan_type: 'North Carolina U.S. House plan'
 }, 'Should determine the right heading text');
 
 assert.equal(plan.which_district_color(NC_2020.districts[0], NC_2020),
@@ -314,7 +310,6 @@ delete headings9.date_only;
 
 assert.deepEqual(headings9, {
     description: 'NC-plan-1-992.geojson (Oct 27: new form, new model, all open, with wins)',
-    plan_type: 'North Carolina U.S. House plan'
 }, 'Should determine the right heading text');
 
 assert.equal(plan.which_district_color(NC_2020_unified.districts[0], NC_2020_unified),


### PR DESCRIPTION
- Used description for H1 insted of redundant plan type text, so that library curator can determine display name
- Implemented state name and house name in header, based on prior `get_plan_type_text()` function
- Moved resources inside top-level section so they don't appear on load failure
- Added website base prefix to resource link icons