### PR TITLE
Hide /upload behind API token 

### DIFF
--- a/cdk-scoring/cdk-scoring.py
+++ b/cdk-scoring/cdk-scoring.py
@@ -606,22 +606,17 @@ class PlanScoreScoring(cdk.Stack):
             ),
         )
 
-        upload_resource.add_method("GET", upload_fields_integration)
+        upload_resource.add_method(
+            "GET",
+            upload_fields_integration,
+            authorizer=token_authorizer,
+        )
 
         upload_resource.add_method(
             "POST",
             api_upload_integration,
             authorizer=token_authorizer,
         )
-
-        upload_interactive_resource = upload_resource.add_resource(
-            'interactive',
-            default_cors_preflight_options=aws_apigateway.CorsOptions(
-                allow_origins=aws_apigateway.Cors.ALL_ORIGINS,
-            ),
-        )
-
-        upload_interactive_resource.add_method("GET", upload_fields_integration)
 
         upload_temporary_resource = upload_resource.add_resource(
             'temporary',
@@ -635,6 +630,15 @@ class PlanScoreScoring(cdk.Stack):
             api_upload_integration,
             authorizer=token_authorizer,
         )
+
+        upload_interactive_resource = upload_resource.add_resource(
+            'interactive',
+            default_cors_preflight_options=aws_apigateway.CorsOptions(
+                allow_origins=aws_apigateway.Cors.ALL_ORIGINS,
+            ),
+        )
+
+        upload_interactive_resource.add_method("GET", upload_fields_integration)
 
         preread_integration = aws_apigateway.LambdaIntegration(
             preread,

--- a/cdk-scoring/cdk-scoring.py
+++ b/cdk-scoring/cdk-scoring.py
@@ -593,12 +593,6 @@ class PlanScoreScoring(cdk.Stack):
             get_states_integration,
         )
 
-        upload_fields_integration = aws_apigateway.LambdaIntegration(
-            upload_fields,
-            credentials_role=apigateway_role,
-            **integration_kwargs
-        )
-
         upload_resource = api.root.add_resource(
             'upload',
             default_cors_preflight_options=aws_apigateway.CorsOptions(
@@ -608,7 +602,7 @@ class PlanScoreScoring(cdk.Stack):
 
         upload_resource.add_method(
             "GET",
-            upload_fields_integration,
+            api_upload_integration,
             authorizer=token_authorizer,
         )
 
@@ -636,6 +630,12 @@ class PlanScoreScoring(cdk.Stack):
             default_cors_preflight_options=aws_apigateway.CorsOptions(
                 allow_origins=aws_apigateway.Cors.ALL_ORIGINS,
             ),
+        )
+
+        upload_fields_integration = aws_apigateway.LambdaIntegration(
+            upload_fields,
+            credentials_role=apigateway_role,
+            **integration_kwargs
         )
 
         upload_interactive_resource.add_method("GET", upload_fields_integration)

--- a/planscore/api_upload.py
+++ b/planscore/api_upload.py
@@ -81,9 +81,10 @@ def lambda_handler(event, context):
     except json.decoder.JSONDecodeError:
         status, body = '400', json.dumps(dict(message='Bad GeoJSON input'))
     else:
-        temporary = event['path'].endswith('/temporary')
+        is_interactive = bool(event['httpMethod'] == 'GET')
+        is_temporary = event['path'].endswith('/temporary')
         auth_token = event['requestContext'].get('authorizer', {}).get('authToken')
-        result = kick_it_off(geojson, temporary, auth_token)
+        result = kick_it_off(geojson, is_temporary, auth_token)
         status, body = '200', json.dumps(result, indent=2)
     
     return {

--- a/planscore/api_upload.py
+++ b/planscore/api_upload.py
@@ -74,6 +74,14 @@ def kick_it_off(geojson, temporary, auth_token):
 def lambda_handler(event, context):
     '''
     '''
+    is_interactive = bool(event['httpMethod'] == 'GET')
+
+    if is_interactive:
+        return {
+            'statusCode': '501',
+            'body': json.dumps({"try": "later"}, indent=2),
+            }
+
     try:
         geojson = json.loads(event['body'])
     except TypeError:
@@ -81,12 +89,6 @@ def lambda_handler(event, context):
     except json.decoder.JSONDecodeError:
         status, body = '400', json.dumps(dict(message='Bad GeoJSON input'))
     else:
-        is_interactive = bool(event['httpMethod'] == 'GET')
-        if is_interactive:
-            return {
-                'statusCode': '501',
-                'body': json.dumps({"try": "later"}, indent=2),
-                }
         is_temporary = event['path'].endswith('/temporary')
         auth_token = event['requestContext'].get('authorizer', {}).get('authToken')
         result = kick_it_off(geojson, is_temporary, auth_token)

--- a/planscore/api_upload.py
+++ b/planscore/api_upload.py
@@ -82,6 +82,11 @@ def lambda_handler(event, context):
         status, body = '400', json.dumps(dict(message='Bad GeoJSON input'))
     else:
         is_interactive = bool(event['httpMethod'] == 'GET')
+        if is_interactive:
+            return {
+                'statusCode': '501',
+                'body': json.dumps({"try": "later"}, indent=2),
+                }
         is_temporary = event['path'].endswith('/temporary')
         auth_token = event['requestContext'].get('authorizer', {}).get('authToken')
         result = kick_it_off(geojson, is_temporary, auth_token)


### PR DESCRIPTION
`GET /upload/interactive` is now the unauthorized endpoint, and `GET /upload` is no longer implemented. Followup to #408.