### PR TITLE
Eliminate multistep timeouts

### DIFF
--- a/cdk-scoring/cdk-scoring.py
+++ b/cdk-scoring/cdk-scoring.py
@@ -432,6 +432,17 @@ class PlanScoreScoring(cdk.Stack):
         grant_function_invoke(run_tile, 'FUNC_NAME_RUN_TILE', postread_calculate)
         grant_function_invoke(run_slice, 'FUNC_NAME_RUN_SLICE', postread_calculate)
 
+        postread_intermediate = aws_lambda.Function(
+            self,
+            "PostreadIntermediate",
+            handler="lambda.postread_intermediate",
+            memory_size=1024,
+            **function_kwargs
+        )
+
+        grant_data_bucket_access(data_bucket, postread_intermediate)
+        grant_function_invoke(postread_calculate, 'FUNC_NAME_POSTREAD_CALCULATE', postread_intermediate)
+
         preread_followup = aws_lambda.Function(
             self,
             "PrereadFollowup",
@@ -514,6 +525,7 @@ class PlanScoreScoring(cdk.Stack):
 
         grant_data_bucket_access(data_bucket, postread_callback)
         grant_function_invoke(postread_calculate, 'FUNC_NAME_POSTREAD_CALCULATE', postread_callback)
+        grant_function_invoke(postread_intermediate, 'FUNC_NAME_POSTREAD_INTERMEDIATE', postread_callback)
         postread_callback.add_permission('Permission', principal=apigateway_role)
 
         return (

--- a/cdk-scoring/cdk-scoring.py
+++ b/cdk-scoring/cdk-scoring.py
@@ -471,17 +471,6 @@ class PlanScoreScoring(cdk.Stack):
         grant_function_invoke(postread_calculate, 'FUNC_NAME_POSTREAD_CALCULATE', api_upload)
         api_upload.add_permission('Permission', principal=apigateway_role)
 
-        postread_callback = aws_lambda.Function(
-            self,
-            "PostreadCallback",
-            handler="lambda.postread_callback",
-            **function_kwargs
-        )
-
-        grant_data_bucket_access(data_bucket, postread_callback)
-        grant_function_invoke(postread_calculate, 'FUNC_NAME_POSTREAD_CALCULATE', postread_callback)
-        postread_callback.add_permission('Permission', principal=apigateway_role)
-
         function_kwargs.update(dict(
             timeout=cdk.Duration.seconds(3),
         ))
@@ -515,6 +504,17 @@ class PlanScoreScoring(cdk.Stack):
         grant_data_bucket_access(data_bucket, preread)
         preread.add_permission('Permission', principal=apigateway_role)
         grant_function_invoke(preread_followup, 'FUNC_NAME_PREREAD_FOLLOWUP', preread)
+
+        postread_callback = aws_lambda.Function(
+            self,
+            "PostreadCallback",
+            handler="lambda.postread_callback",
+            **function_kwargs
+        )
+
+        grant_data_bucket_access(data_bucket, postread_callback)
+        grant_function_invoke(postread_calculate, 'FUNC_NAME_POSTREAD_CALCULATE', postread_callback)
+        postread_callback.add_permission('Permission', principal=apigateway_role)
 
         return (
             authorizer,

--- a/lambda.py
+++ b/lambda.py
@@ -3,6 +3,7 @@ from planscore.preread import lambda_handler as preread
 from planscore.preread_followup import lambda_handler as preread_followup
 from planscore.postread_callback import lambda_handler as postread_callback
 from planscore.postread_calculate import lambda_handler as postread_calculate
+from planscore.postread_intermediate import lambda_handler as postread_intermediate
 from planscore.run_tile import lambda_handler as run_tile
 from planscore.run_slice import lambda_handler as run_slice
 from planscore.observe import lambda_handler as observe_tiles

--- a/planscore/postread_intermediate.py
+++ b/planscore/postread_intermediate.py
@@ -1,0 +1,47 @@
+import os
+import boto3
+import json
+
+from . import data, util, constants, observe, preread_followup, postread_calculate
+
+FUNCTION_NAME = os.environ.get('FUNC_NAME_POSTREAD_INTERMEDIATE') or 'PlanScore-PostreadIntermediate'
+
+def lambda_handler(event, context):
+    '''
+    '''
+    s3 = boto3.client('s3')
+    lam = boto3.client('lambda')
+    storage = data.Storage(s3, event['bucket'], None)
+    upload1 = data.Upload.from_dict(event)
+
+    try:
+        body = json.loads(event['callback_body'])
+    except:
+        print(f"Could not read description and incumbents from {event['callback_body']}.")
+        description = None
+        incumbents = None
+        library_metadata = None
+    else:
+        print(f"Read description and incumbents from {event['callback_body']}...")
+        description = body.get('description', None)
+        incumbents = body.get('incumbents', None)
+        library_metadata = body.get('library_metadata', None)
+
+    upload2 = upload1.clone(
+        message = 'Scoring: Starting analysis.',
+        description = description,
+        incumbents = incumbents,
+        library_metadata = library_metadata,
+    )
+
+    observe.put_upload_index(storage, upload2)
+    upload3 = preread_followup.commence_upload_parsing(s3, lam, event['bucket'], upload2)
+    
+    next_event = dict(bucket=event['bucket'])
+    next_event.update(upload3.to_dict())
+
+    lam.invoke(
+        FunctionName=postread_calculate.FUNCTION_NAME,
+        InvocationType='Event',
+        Payload=json.dumps(next_event).encode('utf8'),
+    )


### PR DESCRIPTION
It wasn't enough to extend the timeout for PostreadCallback, needed to make the whole slow part async in PostreadIntermediate.