### PR TITLE
Fix missing icon on plan pages

### DIFF
--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -203,7 +203,7 @@
 	        mm_metric_url = '{{planscore_website_base}}/metrics/meanmedian/',
 	        d2_metric_url = '{{planscore_website_base}}/metrics/declination/',
 	        metadata_link_img_url = '{{planscore_website_base}}/images/external-link.svg',
-	        metadata_arrow_img_url = '{{planscore_website_base}}/arrow-right.svg',
+	        metadata_arrow_img_url = '{{planscore_website_base}}/images/arrow-right.svg',
 	        metadata_file_img_url = '{{planscore_website_base}}/images/download.svg',
 	        model_url_pattern = '{{ url_for("get_model_description", prefix="data/2020") }}';
 


### PR DESCRIPTION
@migurski noticed a missing icon on plan pages, was missing the `/images/` path.