### PR TITLE
Expose FTVA races at bottom of score pages

### DIFF
--- a/planscore/data.py
+++ b/planscore/data.py
@@ -357,9 +357,9 @@ MODELS = [
     Model(State.AK, House.ushouse,       1,  True, VERSION, 'data/AK/004-fva-votes'), # 423b365
     Model(State.AK, House.statesenate,  20,  True, VERSION, 'data/AK/004-fva-votes'), # 423b365
     Model(State.AK, House.statehouse,   40,  True, VERSION, 'data/AK/004-fva-votes'), # 423b365
-    Model(State.AL, House.ushouse,       7,  True, VERSION, 'data/AL/003-decennial'), # 4ee6b60
-    Model(State.AL, House.statesenate,  35,  True, VERSION, 'data/AL/003-decennial'), # 4ee6b60
-    Model(State.AL, House.statehouse,  105,  True, VERSION, 'data/AL/003-decennial'), # 4ee6b60
+    Model(State.AL, House.ushouse,       7,  True, VERSION, 'data/AL/004-fva-votes'), # 423b365
+    Model(State.AL, House.statesenate,  35,  True, VERSION, 'data/AL/004-fva-votes'), # 423b365
+    Model(State.AL, House.statehouse,  105,  True, VERSION, 'data/AL/004-fva-votes'), # 423b365
     Model(State.AR, House.ushouse,       4,  True, VERSION, 'data/AR/004-fva-votes'), # 423b365
     Model(State.AR, House.statesenate,  35,  True, VERSION, 'data/AR/004-fva-votes'), # 423b365
     Model(State.AR, House.statehouse,  100,  True, VERSION, 'data/AR/004-fva-votes'), # 423b365

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -36,12 +36,14 @@ var FIELDS = [
     'US President 2020 - REP',
     'US President 2016 - DEM',
     'US President 2016 - REP',
+    /*
     'US Senate 2020 - DEM',
     'US Senate 2020 - REP',
     'US Senate 2018 - DEM',
     'US Senate 2018 - REP',
     'US Senate 2016 - DEM',
     'US Senate 2016 - REP',
+    */
     /*, 'Polsby-Popper', 'Reock'*/
 ];
 
@@ -852,7 +854,7 @@ function update_heading_titles(head)
         } else if(head[i] == 'Clinton (D) 2016' && head.indexOf('Biden (D) 2020') >= 0) {
             head[i] = SHY_COLUMN;
 
-        } else  if(head[i] == 'CVAP 2019') {
+        } else if(head[i] == 'CVAP 2019') {
             head[i] = SHY_COLUMN;
         }
     });

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -36,20 +36,14 @@ var FIELDS = [
     'US President 2020 - REP',
     'US President 2016 - DEM',
     'US President 2016 - REP',
+    'US Senate 2020 - DEM',
+    'US Senate 2020 - REP',
+    'US Senate 2018 - DEM',
+    'US Senate 2018 - REP',
+    'US Senate 2016 - DEM',
+    'US Senate 2016 - REP',
     /*, 'Polsby-Popper', 'Reock'*/
 ];
-
-if(typeof location !== 'undefined' && location.hash.match(/\bshowall\b/))
-{
-    FIELDS = FIELDS.concat([
-        'US Senate 2020 - DEM',
-        'US Senate 2020 - REP',
-        'US Senate 2018 - DEM',
-        'US Senate 2018 - REP',
-        'US Senate 2016 - DEM',
-        'US Senate 2016 - REP',
-    ]);
-}
 
 const votesFieldToDisplayStr = {
     'Democratic Votes': 'Democratic Votes',
@@ -753,7 +747,7 @@ function show_library_metadata(plan, metadata_el, geom_prefix)
 
 function show_fva_race_scores(plan, scores_FVA)
 {
-    if('US President 2020 Efficiency Gap' in plan.summary && location.hash.match(/\bshowall\b/))
+    if('US President 2020 Efficiency Gap' in plan.summary)
     {
         var fva_races = [{office: 'U.S. President', year: '2020', gap: plan.summary['US President 2020 Efficiency Gap']}];
 

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -774,8 +774,25 @@ function show_ftva_race_scores(plan, scores_FTVA)
             var score_FTVA = scores_FTVA[i],
                 //summary_name = which_score_summary_name(plan),
                 gap = ftva_races[i].gap,
-                gap_amount = nice_percent(Math.abs(gap));
+                gap_amount = nice_percent(Math.abs(gap)),
+                win_party = (gap < 0 ? 'Republican' : 'Democratic'),
+                win_partisans = (gap < 0 ? 'Republicans' : 'Democrats'),
+                lose_party = (gap < 0 ? 'Democratic' : 'Republican');
 
+            clear_element(score_FTVA);
+
+            score_FTVA.innerHTML = `
+                <h5>${ftva_races[i].office} ${ftva_races[i].year}: ${gap_amount}</h5>
+                <p>
+                Under this plan, votes for the ${win_party}
+                candidate <!--for ${ftva_races[i].office} in
+                ${ftva_races[i].year}--> were inefficient at a rate
+                ${gap_amount} lower than votes for the
+                ${lose_party} candidate.
+                </p>
+                `;
+
+            /*
             for(node = score_FTVA.firstChild; node = node.nextSibling; node)
             {
                 if(node.nodeName == 'H3') {
@@ -801,6 +818,7 @@ function show_ftva_race_scores(plan, scores_FTVA)
                         `;
                 }
             }
+            */
         }
     } else {
         for(var i = 0; i < scores_FTVA.length; i++)

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -747,39 +747,39 @@ function show_library_metadata(plan, metadata_el, geom_prefix)
     console.log(links);
 }
 
-function show_fva_race_scores(plan, scores_FVA)
+function show_ftva_race_scores(plan, scores_FTVA)
 {
     if('US President 2020 Efficiency Gap' in plan.summary)
     {
-        var fva_races = [{office: 'U.S. President', year: '2020', gap: plan.summary['US President 2020 Efficiency Gap']}];
+        var ftva_races = [{office: 'U.S. President', year: '2020', gap: plan.summary['US President 2020 Efficiency Gap']}];
 
         if('US President 2016 Efficiency Gap' in plan.summary) {
-            fva_races.push({office: 'U.S. President', year: '2016', gap: plan.summary['US President 2016 Efficiency Gap']});
+            ftva_races.push({office: 'U.S. President', year: '2016', gap: plan.summary['US President 2016 Efficiency Gap']});
         }
         
         if('US Senate 2020 Efficiency Gap' in plan.summary) {
-            fva_races.push({office: 'U.S. Senate', year: '2020', gap: plan.summary['US Senate 2020 Efficiency Gap']});
+            ftva_races.push({office: 'U.S. Senate', year: '2020', gap: plan.summary['US Senate 2020 Efficiency Gap']});
         }
         
         if('US Senate 2018 Efficiency Gap' in plan.summary) {
-            fva_races.push({office: 'U.S. Senate', year: '2018', gap: plan.summary['US Senate 2018 Efficiency Gap']});
+            ftva_races.push({office: 'U.S. Senate', year: '2018', gap: plan.summary['US Senate 2018 Efficiency Gap']});
         }
         
         if('US Senate 2016 Efficiency Gap' in plan.summary) {
-            fva_races.push({office: 'U.S. Senate', year: '2016', gap: plan.summary['US Senate 2016 Efficiency Gap']});
+            ftva_races.push({office: 'U.S. Senate', year: '2016', gap: plan.summary['US Senate 2016 Efficiency Gap']});
         }
         
-        for(var i = 0; i < scores_FVA.length && i < fva_races.length; i++)
+        for(var i = 0; i < scores_FTVA.length && i < ftva_races.length; i++)
         {
-            var score_FVA = scores_FVA[i],
+            var score_FTVA = scores_FTVA[i],
                 //summary_name = which_score_summary_name(plan),
-                gap = fva_races[i].gap,
+                gap = ftva_races[i].gap,
                 gap_amount = nice_percent(Math.abs(gap));
 
-            for(node = score_FVA.firstChild; node = node.nextSibling; node)
+            for(node = score_FTVA.firstChild; node = node.nextSibling; node)
             {
                 if(node.nodeName == 'H3') {
-                    node.innerHTML = `${fva_races[i].office} ${fva_races[i].year}: ${gap_amount}`;
+                    node.innerHTML = `${ftva_races[i].office} ${ftva_races[i].year}: ${gap_amount}`;
 
                 } else if(node.nodeName == 'DIV') {
                     drawBiasBellChart('eg', gap, node.id,
@@ -794,8 +794,8 @@ function show_fva_race_scores(plan, scores_FVA)
         
                     node.innerHTML = `
                         Under this plan, votes for the ${win_party}
-                        candidate for ${fva_races[i].office} in
-                        ${fva_races[i].year} were inefficient at a rate
+                        candidate for ${ftva_races[i].office} in
+                        ${ftva_races[i].year} were inefficient at a rate
                         ${gap_amount} lower than votes for the
                         ${lose_party} candidate.
                         `;
@@ -803,9 +803,9 @@ function show_fva_race_scores(plan, scores_FVA)
             }
         }
     } else {
-        for(var i = 0; i < scores_FVA.length; i++)
+        for(var i = 0; i < scores_FTVA.length; i++)
         {
-            scores_FVA[i].parentNode.style.display = 'none';
+            scores_FTVA[i].parentNode.style.display = 'none';
         }
     }
 }
@@ -1226,13 +1226,13 @@ function plan_has_incumbency(plan)
 function start_load_plan_polling(url, message_section, score_section,
     description_el, metadata_el, model_link, model_footnote, model_url_pattern,
     districts_table, metrics_table, score_EG, score_PB, score_MM, score_DEC2,
-    score_sense, scores_FVA, text_url, text_link, geom_prefix, map_div, seat_count)
+    score_sense, scores_FTVA, text_url, text_link, geom_prefix, map_div, seat_count)
 {
     const make_xhr = () => {
         load_plan_score(url, message_section, score_section,
             description_el, metadata_el, model_link, model_footnote, model_url_pattern,
             districts_table, metrics_table, score_EG, score_PB, score_MM,
-            score_DEC2, score_sense, scores_FVA, text_url, text_link, geom_prefix, map_div,
+            score_DEC2, score_sense, scores_FTVA, text_url, text_link, geom_prefix, map_div,
             seat_count, xhr_retry_callback);
     };
 
@@ -1249,7 +1249,7 @@ function start_load_plan_polling(url, message_section, score_section,
 function load_plan_score(url, message_section, score_section,
     description_el, metadata_el, model_link, model_footnote, model_url_pattern,
     districts_table, metrics_table, score_EG, score_PB, score_MM, score_DEC2,
-    score_sense, scores_FVA, text_url, text_link, geom_prefix, map_div, seat_count,
+    score_sense, scores_FTVA, text_url, text_link, geom_prefix, map_div, seat_count,
     xhr_retry_callback)
 {
     var request = new XMLHttpRequest();
@@ -1428,7 +1428,7 @@ function load_plan_score(url, message_section, score_section,
         }
 
         show_metrics_table(plan, metrics_table);
-        show_fva_race_scores(plan, scores_FVA);
+        show_ftva_race_scores(plan, scores_FTVA);
         
         if('library_metadata' in plan && plan['library_metadata']) {
             show_library_metadata(plan, metadata_el, geom_prefix);

--- a/planscore/website/static/plan.js
+++ b/planscore/website/static/plan.js
@@ -782,7 +782,7 @@ function show_ftva_race_scores(plan, scores_FTVA)
                     node.innerHTML = `${ftva_races[i].office} ${ftva_races[i].year}: ${gap_amount}`;
 
                 } else if(node.nodeName == 'DIV') {
-                    drawBiasBellChart('eg', gap, node.id,
+                    drawBiasBellChart('ftva', gap, node.id,
                         (plan.model ? plan.model.house : 'ushouse'), 'plan');
 
                 } else if(node.nodeName == 'P') {

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -119,13 +119,13 @@
     <p id="map"></p>
     <h2>District Data</h2>
     <hr />
-    <div class="col-xs-12 col-sm-12  table-jehl table-districts">
+    <div class="table-jehl table-districts">
         <table class="table table-hover" id="districts">
             {# this table will be populated by load_plan_score() #}
         </table>
     </div>
     <a href="#" id="text-link">Download raw data as tab-delimited text</a>.
-    <div class="col-xs-12 col-sm-12 table-jehl table-metrics">
+    <div class="table-jehl table-metrics">
         <table class="table table-hover" id="metrics">
             {# this table will be populated by load_plan_score() #}
         </table>

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -135,12 +135,10 @@
         <li class="col-md-4">
             <h3>Freedom to Vote Act Races</h3>
             <p>
-                “The Act specifies exactly what data should be employed for this
-                purpose: the two most recent presidential elections and the two
-                most recent Senate elections in a state. An enacted plan’s bias
-                has to be computed with respect to each of those four
-                elections.”
-                (<a href="https://electionlawblog.org/?p=124617">Nicholas Stephanopolous</a>)
+                <a href="https://www.congress.gov/bill/117th-congress/senate-bill/2747/text">Section 5003(c)(3) of the FTVA</a>
+                specifies that partisan fairness should be assessed using a
+                state's two most recent elections for U.S. President and two
+                most recent elections for U.S. Senate.
             </p>
         </li>
         <li class="col-md-4" id="score-fva1-efficiency-gap">

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -141,6 +141,11 @@
                 most recent elections for U.S. Senate.
             </p>
         </li>
+        <li class="col-md-2" id="score-ftva1-efficiency-gap">EG 1</li>
+        <li class="col-md-2" id="score-ftva2-efficiency-gap">EG 2</li>
+        <li class="col-md-2" id="score-ftva3-efficiency-gap">EG 3</li>
+        <li class="col-md-2" id="score-ftva4-efficiency-gap">EG 4</li>
+        {#
         <li class="col-md-4" id="score-ftva1-efficiency-gap">
             <h3>FTVA Efficiency Gap 1</h3>
             <div class="metric-bellchart" id="metric-bellchart-ftva1-eg">
@@ -193,6 +198,7 @@
             </div>
             <p>Not enough information to calculate this score.</p>
         </li>
+        #}
     </ul>
 
     <p><small>

--- a/planscore/website/templates/plan.html
+++ b/planscore/website/templates/plan.html
@@ -141,9 +141,9 @@
                 most recent elections for U.S. Senate.
             </p>
         </li>
-        <li class="col-md-4" id="score-fva1-efficiency-gap">
-            <h3>FVA Efficiency Gap 1</h3>
-            <div class="metric-bellchart" id="metric-bellchart-fva1-eg">
+        <li class="col-md-4" id="score-ftva1-efficiency-gap">
+            <h3>FTVA Efficiency Gap 1</h3>
+            <div class="metric-bellchart" id="metric-bellchart-ftva1-eg">
                 <div class="curve"><div class="marklabel">This Plan</div><div class="markline"></div></div>
                 <div class="row metric-bellchart-legend">
                     <div class="col-xs-4 left">+<span data-field="metric-bellchart-spread"></span>% D</div>
@@ -153,9 +153,9 @@
             </div>
             <p>Not enough information to calculate this score.</p>
         </li>
-        <li class="col-md-4" id="score-fva2-efficiency-gap">
-            <h3>FVA Efficiency Gap 2</h3>
-            <div class="metric-bellchart" id="metric-bellchart-fva2-eg">
+        <li class="col-md-4" id="score-ftva2-efficiency-gap">
+            <h3>FTVA Efficiency Gap 2</h3>
+            <div class="metric-bellchart" id="metric-bellchart-ftva2-eg">
                 <div class="curve"><div class="marklabel">This Plan</div><div class="markline"></div></div>
                 <div class="row metric-bellchart-legend">
                     <div class="col-xs-4 left">+<span data-field="metric-bellchart-spread"></span>% D</div>
@@ -169,9 +169,9 @@
     <ul class="row scores-box">
         <li class="col-md-2">
         </li>
-        <li class="col-md-4" id="score-fva3-efficiency-gap">
-            <h3>FVA Efficiency Gap 3</h3>
-            <div class="metric-bellchart" id="metric-bellchart-fva3-eg">
+        <li class="col-md-4" id="score-ftva3-efficiency-gap">
+            <h3>FTVA Efficiency Gap 3</h3>
+            <div class="metric-bellchart" id="metric-bellchart-ftva3-eg">
                 <div class="curve"><div class="marklabel">This Plan</div><div class="markline"></div></div>
                 <div class="row metric-bellchart-legend">
                     <div class="col-xs-4 left">+<span data-field="metric-bellchart-spread"></span>% D</div>
@@ -181,9 +181,9 @@
             </div>
             <p>Not enough information to calculate this score.</p>
         </li>
-        <li class="col-md-4" id="score-fva4-efficiency-gap">
-            <h3>FVA Efficiency Gap 4</h3>
-            <div class="metric-bellchart" id="metric-bellchart-fva4-eg">
+        <li class="col-md-4" id="score-ftva4-efficiency-gap">
+            <h3>FTVA Efficiency Gap 4</h3>
+            <div class="metric-bellchart" id="metric-bellchart-ftva4-eg">
                 <div class="curve"><div class="marklabel">This Plan</div><div class="markline"></div></div>
                 <div class="row metric-bellchart-legend">
                     <div class="col-xs-4 left">+<span data-field="metric-bellchart-spread"></span>% D</div>
@@ -289,10 +289,10 @@
 	        document.getElementById('score-declination'),
 	        document.getElementById('score-sensitivity'),
             [
-                document.getElementById('score-fva1-efficiency-gap'),
-                document.getElementById('score-fva2-efficiency-gap'),
-                document.getElementById('score-fva3-efficiency-gap'),
-                document.getElementById('score-fva4-efficiency-gap'),
+                document.getElementById('score-ftva1-efficiency-gap'),
+                document.getElementById('score-ftva2-efficiency-gap'),
+                document.getElementById('score-ftva3-efficiency-gap'),
+                document.getElementById('score-ftva4-efficiency-gap'),
             ],
 	        text_url,
 	        document.getElementById('text-link'),


### PR DESCRIPTION
Uses no curves for FTVA races, like this US House plan example:

<img width="1017" alt="Screen Shot 2021-10-03 at 4 16 41 PM" src="https://user-images.githubusercontent.com/58730/135775187-fd99834b-1016-4b00-bdb3-7c5cee1fe60f.png">


