### PR TITLE
Add missing auth token to multistep API requests

### DIFF
--- a/planscore/data.py
+++ b/planscore/data.py
@@ -357,6 +357,9 @@ class Upload:
             
             # User-selected model version
             self.model_version,
+
+            # State machine execution
+            self.execution_id,
         ]
         
         try:

--- a/planscore/data.py
+++ b/planscore/data.py
@@ -252,6 +252,18 @@ class Upload:
         ds = datetime.date.fromtimestamp(self.start_time).strftime('%Y-%m-%d')
         return UPLOAD_LOGENTRY_KEY.format(ds=ds, guid=guid)
     
+    def obscured_token(self):
+        '''An obscured version of the token safe for logs, etc.
+        '''
+        if not self.auth_token:
+            return None
+
+        if self.auth_token.endswith('********'):
+            # Already obscured, bravo
+            return self.auth_token
+
+        return self.auth_token[:len(self.auth_token)//2] + '********'
+
     def to_plaintext(self):
         ''' Export district totals to a tab-delimited plaintext file
         '''
@@ -306,6 +318,7 @@ class Upload:
             geometry_key = self.geometry_key,
             commit_sha = self.commit_sha,
             library_metadata = self.library_metadata,
+            auth_token = self.obscured_token(),
             model_version = self.model_version,
             execution_id = self.execution_id,
             execution_token = self.execution_token,
@@ -317,11 +330,6 @@ class Upload:
     def to_logentry(self):
         ''' Export current plan information to a tab-delimited plaintext file
         '''
-        if self.auth_token:
-            obscured_token = self.auth_token[:len(self.auth_token)//2] + '********'
-        else:
-            obscured_token = None
-        
         # Important: only append to this list to maintain 
         # backward-compatibility with older entries for PrestoDB
         logentry = [
@@ -353,7 +361,7 @@ class Upload:
             {True: 't', False: 'f', None: ''}.get(self.status),
             
             # Auth token
-            obscured_token,
+            self.obscured_token(),
             
             # User-selected model version
             self.model_version,
@@ -388,7 +396,7 @@ class Upload:
             description = description or self.description,
             geometry_key = geometry_key or self.geometry_key,
             library_metadata = library_metadata or self.library_metadata,
-            auth_token = auth_token,
+            auth_token = auth_token or self.obscured_token(),
             model_version = model_version or self.model_version,
             execution_id = execution_id or self.execution_id,
             execution_token = execution_token or self.execution_token,

--- a/planscore/postread_callback.py
+++ b/planscore/postread_callback.py
@@ -121,11 +121,13 @@ def lambda_handler_POST(event, context):
         }, indent=2),
     }
 
-    upload = preread.create_upload(s3, query['bucket'], query['key'], id)
-    observe.put_upload_index(storage, upload)
+    auth_token = event['requestContext'].get('authorizer', {}).get('planscoreApiToken')
+    upload1 = preread.create_upload(s3, query['bucket'], query['key'], id)
+    upload2 = upload1.clone(auth_token=auth_token)
+    observe.put_upload_index(storage, upload2)
 
     event = dict(bucket=query['bucket'], callback_body=event['body'])
-    event.update(upload.to_dict())
+    event.update(upload2.to_dict())
 
     sfn.start_execution(
         stateMachineArn=os.environ.get('MULTISTEP_API_SCORE_MACHINE'),

--- a/planscore/tests/test_data.py
+++ b/planscore/tests/test_data.py
@@ -267,7 +267,7 @@ class TestData (unittest.TestCase):
         upload21 = data.Upload(id='ID', key='uploads/ID/upload/whatever.json',
             auth_token='Heyo')
 
-        self.assertIsNone(json.loads(upload21.to_json()).get('auth_token'))
+        self.assertEqual(json.loads(upload21.to_json())['auth_token'], 'He********')
     
         upload22 = data.Upload(id='ID', key='uploads/ID/upload/whatever.json',
             library_metadata={'key': 'value'})
@@ -354,15 +354,15 @@ class TestData (unittest.TestCase):
         
         upload1 = data.Upload(id='ID', message='Yo.', key='whatever')
         logentry1 = upload1.to_logentry()
-        self.assertEqual(logentry1, 'ID\t-999\t0\tYo.\t\t\t\twhatever\t\t\t\r\n')
+        self.assertEqual(logentry1, 'ID\t-999\t0\tYo.\t\t\t\twhatever\t\t\t\t\r\n')
 
         upload2 = data.Upload(id='ID', message="Hell's Bells", key='whatever', status=True)
         logentry2 = upload2.to_logentry()
-        self.assertEqual(logentry2, "ID\t-999\t0\tHell's Bells\t\t\t\twhatever\tt\t\t\r\n")
+        self.assertEqual(logentry2, "ID\t-999\t0\tHell's Bells\t\t\t\twhatever\tt\t\t\t\r\n")
 
         upload3 = data.Upload(id='ID', message="Oh, really?", key='whatever', status=False)
         logentry3 = upload3.to_logentry()
-        self.assertEqual(logentry3, 'ID\t-999\t0\tOh, really?\t\t\t\twhatever\tf\t\t\r\n')
+        self.assertEqual(logentry3, 'ID\t-999\t0\tOh, really?\t\t\t\twhatever\tf\t\t\t\r\n')
         
         upload4 = data.Upload(
             id='ID', message='Yo.', key='whatever',
@@ -371,15 +371,15 @@ class TestData (unittest.TestCase):
         logentry4 = upload4.to_logentry()
         self.assertEqual(logentry4, 'ID\t-999\t0\tYo.\tNC\tushouse\t'
             '{"house":"ushouse","incumbency":false,"key_prefix":"data/NC/001","seats":13,"state":"NC","versions":["2020"]}'
-            '\twhatever\t\t\t\r\n')
+            '\twhatever\t\t\t\t\r\n')
 
         upload5 = data.Upload(id='ID', message="Hell's Bells", key='whatever', auth_token='Heyo')
         logentry5 = upload5.to_logentry()
-        self.assertEqual(logentry5, "ID\t-999\t0\tHell's Bells\t\t\t\twhatever\t\tHe********\t\r\n")
+        self.assertEqual(logentry5, "ID\t-999\t0\tHell's Bells\t\t\t\twhatever\t\tHe********\t\t\r\n")
 
         upload6 = data.Upload(id='ID', message="Hell's Bells", key='whatever', model_version='1999A')
         logentry6 = upload6.to_logentry()
-        self.assertEqual(logentry6, "ID\t-999\t0\tHell's Bells\t\t\t\twhatever\t\t\t1999A\r\n")
+        self.assertEqual(logentry6, "ID\t-999\t0\tHell's Bells\t\t\t\twhatever\t\t\t1999A\t\r\n")
 
     def test_upload_index_key(self):
         ''' data.Upload.index_key() correctly munges Upload.key
@@ -485,7 +485,7 @@ class TestData (unittest.TestCase):
         output10 = input.clone()
         self.assertEqual(output10.id, input.id)
         self.assertEqual(output10.key, input.key)
-        self.assertIsNone(output10.auth_token)
+        self.assertEqual(output10.auth_token, 'fa********')
 
         output11 = input.clone(auth_token='Heyo')
         self.assertEqual(output11.id, input.id)

--- a/planscore/tests/test_postread_callback.py
+++ b/planscore/tests/test_postread_callback.py
@@ -165,6 +165,9 @@ class TestPostreadCallback (unittest.TestCase):
         self.assertIn('"description": "A fine new plan"', payload['callback_body'])
         self.assertIn('"incumbents": ["R", "D"]', payload['callback_body'])
         self.assertIn('"library_metadata": {"Hello": "World"}', payload['callback_body'])
+
+        logentry_body = boto3_client.return_value.put_object.mock_calls[-1][2]['Body']
+        self.assertIn(b'\ty********\t', logentry_body, 'Should see *obscured* "yup" token')
     
     @unittest.mock.patch('planscore.postread_callback.dummy_upload')
     @unittest.mock.patch('boto3.client')

--- a/planscore/tests/test_postread_callback.py
+++ b/planscore/tests/test_postread_callback.py
@@ -167,7 +167,7 @@ class TestPostreadCallback (unittest.TestCase):
         self.assertIn('"library_metadata": {"Hello": "World"}', payload['callback_body'])
 
         logentry_body = boto3_client.return_value.put_object.mock_calls[-1][2]['Body']
-        self.assertIn(b'\ty********\t', logentry_body, 'Should see *obscured* "yup" token')
+        self.assertEqual(logentry_body.split(b'\t')[9], b'y********')
     
     @unittest.mock.patch('planscore.postread_callback.dummy_upload')
     @unittest.mock.patch('boto3.client')


### PR DESCRIPTION
These tokens were being omitted from the logs, bring them back.

Also, track execution IDs to make it easier to connect tokens to API access methods via logs.